### PR TITLE
feat(web_view): 앱 통째 웹뷰 마이그레이션용 라우트 추가

### DIFF
--- a/src/app/web_view/Board/[slug]/_components/PosterGrid.tsx
+++ b/src/app/web_view/Board/[slug]/_components/PosterGrid.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import type { ResponsePost } from '@/lib/types/post';
+
+// Loose attachment shape — `ResponsePost.attachments` isn't typed on
+// `ResponsePost` directly, so we describe what we need.
+interface AttachmentLike {
+    file: string;
+    mimetype?: string;
+}
+
+interface PosterGridProps {
+    posts: ResponsePost[];
+}
+
+function findImage(attachments: unknown): AttachmentLike | undefined {
+    if (!Array.isArray(attachments)) return undefined;
+    return (attachments as AttachmentLike[]).find((a) => {
+        if (!a) return false;
+        if (a.mimetype) return a.mimetype.startsWith('image');
+        return /\.(png|jpe?g|gif|webp|svg)$/i.test(a.file ?? '');
+    });
+}
+
+export function PosterGrid({ posts }: PosterGridProps) {
+    return (
+        <div
+            style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 'var(--ara-spacing-md)',
+                padding: 'var(--ara-spacing-lg)',
+            }}
+        >
+            {posts.map((post) => {
+                // attachments live on the article but ResponsePost doesn't list them;
+                // pull through an unknown cast.
+                const img = findImage(
+                    (post as unknown as { attachments?: AttachmentLike[] }).attachments,
+                );
+                return (
+                    <Link
+                        key={post.id}
+                        href={`/web_view/Post/${post.id}`}
+                        style={{
+                            display: 'block',
+                            textDecoration: 'none',
+                            color: 'inherit',
+                        }}
+                    >
+                        <div
+                            style={{
+                                width: '100%',
+                                aspectRatio: '210/297',
+                                position: 'relative',
+                                overflow: 'hidden',
+                                borderRadius: 'var(--ara-radius-md)',
+                                border: '1px solid var(--ara-divider)',
+                                background: 'var(--ara-bg-muted)',
+                            }}
+                        >
+                            {img ? (
+                                <Image
+                                    src={img.file}
+                                    alt={post.title}
+                                    fill
+                                    sizes="(max-width: 768px) 50vw, 25vw"
+                                    style={{ objectFit: 'cover' }}
+                                />
+                            ) : (
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        inset: 0,
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        color: 'var(--ara-text-quaternary)',
+                                        fontSize: 12,
+                                    }}
+                                >
+                                    이미지 없음
+                                </div>
+                            )}
+                        </div>
+                        <div
+                            style={{
+                                marginTop: 8,
+                                fontSize: 13,
+                                fontWeight: 500,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                            }}
+                            title={post.title}
+                        >
+                            {post.title}
+                        </div>
+                    </Link>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/app/web_view/Board/[slug]/page.tsx
+++ b/src/app/web_view/Board/[slug]/page.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { fetchArticles, fetchBoardList } from '@/lib/api/board';
+import type { ResponsePost } from '@/lib/types/post';
+import { ArticleRow, ArticleRowSkeleton } from '../_components/ArticleRow';
+import { Fab } from '../_components/Fab';
+import { SearchIconButton } from '../_components/SearchTrigger';
+import { PosterGrid } from './_components/PosterGrid';
+
+interface BoardItem {
+    id: number;
+    slug: string;
+    ko_name: string;
+    en_name?: string;
+    name_type?: number;
+}
+
+const POSTER_SLUGS = new Set(['poster', 'poster-general']);
+const POSTER_BOARD_ID = 19;
+const PAGE_SIZE = 20;
+
+export default function BoardSlugPage() {
+    const router = useRouter();
+    const params = useParams<{ slug: string }>();
+    const slug = params?.slug;
+
+    const [board, setBoard] = useState<BoardItem | null>(null);
+    const [posts, setPosts] = useState<ResponsePost[]>([]);
+    const [page, setPage] = useState(1);
+    const [totalPages, setTotalPages] = useState<number | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [boardError, setBoardError] = useState(false);
+
+    const isPoster = useMemo(
+        () => !!board && (POSTER_SLUGS.has(board.slug) || board.id === POSTER_BOARD_ID),
+        [board],
+    );
+
+    // Resolve slug -> board metadata.
+    useEffect(() => {
+        if (!slug) return;
+        let cancelled = false;
+        fetchBoardList()
+            .then((res) => {
+                const list: BoardItem[] = Array.isArray(res) ? res : (res?.results ?? []);
+                const match = list.find((b) => b.slug === slug);
+                if (cancelled) return;
+                if (!match) {
+                    setBoardError(true);
+                    return;
+                }
+                setBoard(match);
+            })
+            .catch(() => {
+                if (!cancelled) setBoardError(true);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [slug]);
+
+    // Reset paging when the board changes.
+    useEffect(() => {
+        setPosts([]);
+        setPage(1);
+        setTotalPages(null);
+    }, [board?.id]);
+
+    // Fetch one page.
+    const loadPage = useCallback(
+        async (boardId: number, pageNum: number) => {
+            setLoading(true);
+            try {
+                const res = await fetchArticles({
+                    boardId,
+                    page: pageNum,
+                    pageSize: PAGE_SIZE,
+                });
+                const results: ResponsePost[] = res.results ?? [];
+                setPosts((prev) => (pageNum === 1 ? results : [...prev, ...results]));
+                setTotalPages(res.num_pages ?? 1);
+            } catch {
+                // swallow — keep what we have
+            } finally {
+                setLoading(false);
+            }
+        },
+        [],
+    );
+
+    useEffect(() => {
+        if (!board) return;
+        loadPage(board.id, page);
+    }, [board, page, loadPage]);
+
+    // IntersectionObserver-driven infinite scroll.
+    const sentinelRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+        const node = sentinelRef.current;
+        if (!node) return;
+        if (loading) return;
+        if (totalPages !== null && page >= totalPages) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((e) => e.isIntersecting)) {
+                    setPage((p) => p + 1);
+                }
+            },
+            { rootMargin: '200px' },
+        );
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, [loading, page, totalPages, posts.length]);
+
+    if (boardError) {
+        return (
+            <Screen>
+                <AppHeader title="게시판" />
+                <div
+                    style={{
+                        padding: 'var(--ara-spacing-xl)',
+                        textAlign: 'center',
+                        color: 'var(--ara-text-tertiary)',
+                    }}
+                >
+                    존재하지 않는 게시판입니다.
+                </div>
+            </Screen>
+        );
+    }
+
+    return (
+        <Screen>
+            <AppHeader
+                title={board?.ko_name ?? ''}
+                trailing={
+                    <SearchIconButton
+                        onClick={() =>
+                            router.push(
+                                `/web_view/Search?board=${encodeURIComponent(slug ?? '')}`,
+                            )
+                        }
+                    />
+                }
+            />
+
+            {board === null && (
+                <div>
+                    {Array.from({ length: 6 }).map((_, i) => (
+                        <ArticleRowSkeleton key={i} />
+                    ))}
+                </div>
+            )}
+
+            {board && isPoster && <PosterGrid posts={posts} />}
+
+            {board && !isPoster && (
+                <div>
+                    {posts.map((post) => (
+                        <ArticleRow key={post.id} post={post} />
+                    ))}
+                </div>
+            )}
+
+            {board && posts.length === 0 && !loading && (
+                <div
+                    style={{
+                        padding: 'var(--ara-spacing-xl)',
+                        textAlign: 'center',
+                        color: 'var(--ara-text-tertiary)',
+                    }}
+                >
+                    게시물이 없습니다.
+                </div>
+            )}
+
+            {board && loading && (
+                <div>
+                    {Array.from({ length: 3 }).map((_, i) => (
+                        <ArticleRowSkeleton key={`load-${i}`} />
+                    ))}
+                </div>
+            )}
+
+            {/* Sentinel for IntersectionObserver-driven pagination. */}
+            <div ref={sentinelRef} aria-hidden style={{ height: 1 }} />
+
+            {board && (
+                <Fab
+                    href={`/web_view/PostWrite?board=${board.id}`}
+                    aboveTabBar={false}
+                />
+            )}
+        </Screen>
+    );
+}

--- a/src/app/web_view/Board/_components/ArticleRow.tsx
+++ b/src/app/web_view/Board/_components/ArticleRow.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import Link from 'next/link';
+import type { ResponsePost } from '@/lib/types/post';
+
+interface ArticleRowProps {
+    post: ResponsePost;
+    /** Show the board name beside the meta line (used in feeds that mix boards). */
+    showBoard?: boolean;
+    /** Show a leading rank index (1-based). */
+    rank?: number;
+}
+
+/**
+ * A single article row styled to feel native. Tapping the row pushes
+ * `/web_view/Post/{id}` so it works inside the WebView shell. We render our
+ * own row instead of reusing `@/components/ArticleList/ArticleList` because
+ * that component hardcodes `/post/{id}` hrefs.
+ */
+export function ArticleRow({ post, showBoard, rank }: ArticleRowProps) {
+    const author = post.created_by?.profile?.nickname ?? '익명';
+    const boardName = post.parent_board?.ko_name ?? '';
+    const topicName = post.parent_topic?.ko_name ?? '';
+
+    return (
+        <Link
+            href={`/web_view/Post/${post.id}`}
+            className="ara-list-row"
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--ara-spacing-md)',
+                textDecoration: 'none',
+                color: 'inherit',
+            }}
+        >
+            {typeof rank === 'number' && (
+                <span
+                    style={{
+                        color: 'var(--ara-primary)',
+                        fontWeight: 700,
+                        fontSize: 18,
+                        width: 20,
+                        flexShrink: 0,
+                        textAlign: 'center',
+                    }}
+                >
+                    {rank}
+                </span>
+            )}
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                    style={{
+                        fontSize: 15,
+                        fontWeight: 500,
+                        color: 'var(--ara-text-primary)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                    title={post.title}
+                >
+                    {topicName && (
+                        <span style={{ color: 'var(--ara-primary)', marginRight: 4 }}>
+                            [{topicName}]
+                        </span>
+                    )}
+                    {post.title}
+                </div>
+                <div
+                    style={{
+                        marginTop: 4,
+                        fontSize: 12,
+                        color: 'var(--ara-text-tertiary)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        overflow: 'hidden',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {showBoard && boardName && (
+                        <>
+                            <span
+                                style={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    maxWidth: 120,
+                                }}
+                            >
+                                {boardName}
+                            </span>
+                            <span aria-hidden>·</span>
+                        </>
+                    )}
+                    <span
+                        style={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            maxWidth: 120,
+                        }}
+                    >
+                        {author}
+                    </span>
+                    <span aria-hidden>·</span>
+                    <span>댓 {post.comment_count ?? 0}</span>
+                    <span aria-hidden>·</span>
+                    <span>
+                        ▲ {post.positive_vote_count ?? 0}
+                    </span>
+                </div>
+            </div>
+        </Link>
+    );
+}
+
+export function ArticleRowSkeleton() {
+    return (
+        <div
+            className="ara-list-row"
+            style={{ display: 'flex', flexDirection: 'column', gap: 6 }}
+        >
+            <div className="ara-skeleton" style={{ height: 16, width: '70%' }} />
+            <div className="ara-skeleton" style={{ height: 12, width: '40%' }} />
+        </div>
+    );
+}

--- a/src/app/web_view/Board/_components/BoardHeader.tsx
+++ b/src/app/web_view/Board/_components/BoardHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+/**
+ * Custom large header for the Board (게시판) tab root. Mirrors the home tab
+ * header style — no back button.
+ */
+export function BoardHeader() {
+    return (
+        <header
+            style={{
+                position: 'sticky',
+                top: 0,
+                zIndex: 40,
+                background: 'var(--ara-bg)',
+                borderBottom: '1px solid var(--ara-divider)',
+                padding: '12px var(--ara-spacing-lg)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+            }}
+        >
+            <h1
+                style={{
+                    margin: 0,
+                    color: 'var(--ara-text-primary)',
+                    fontSize: 22,
+                    fontWeight: 700,
+                }}
+            >
+                게시판
+            </h1>
+        </header>
+    );
+}

--- a/src/app/web_view/Board/_components/Fab.tsx
+++ b/src/app/web_view/Board/_components/Fab.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { bridge } from '@/app/web_view/_bridge';
+
+interface FabProps {
+    href: string;
+    label?: string;
+    aboveTabBar?: boolean;
+}
+
+/**
+ * Floating action button (bottom-right). Used for "글 쓰기" entry points.
+ * Sits above the safe area and (optionally) above the bottom tab bar.
+ */
+export function Fab({ href, label = '글 쓰기', aboveTabBar = true }: FabProps) {
+    return (
+        <Link
+            href={href}
+            onClick={() => {
+                try {
+                    bridge?.send('haptic', { kind: 'light' });
+                } catch {
+                    /* no-op in browser */
+                }
+            }}
+            aria-label={label}
+            style={{
+                position: 'fixed',
+                right: 'calc(var(--ara-spacing-lg) + var(--ara-safe-right))',
+                bottom: aboveTabBar
+                    ? 'calc(var(--ara-tab-height) + var(--ara-safe-bottom) + var(--ara-spacing-lg))'
+                    : 'calc(var(--ara-safe-bottom) + var(--ara-spacing-lg))',
+                width: 56,
+                height: 56,
+                borderRadius: 999,
+                background: 'var(--ara-primary)',
+                color: 'var(--ara-text-on-primary)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                boxShadow: '0 6px 16px rgba(237, 58, 58, 0.35)',
+                zIndex: 30,
+                textDecoration: 'none',
+            }}
+        >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <path
+                    d="M4 20L4 17L15 6L18 9L7 20L4 20Z"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinejoin="round"
+                />
+                <path
+                    d="M14 7L17 10"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                />
+            </svg>
+        </Link>
+    );
+}

--- a/src/app/web_view/Board/_components/SearchTrigger.tsx
+++ b/src/app/web_view/Board/_components/SearchTrigger.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+interface SearchTriggerProps {
+    /** Where to push when tapped. */
+    target?: string;
+    placeholder?: string;
+}
+
+/**
+ * Read-only-looking search bar that pushes to a real search screen on tap.
+ * Used at the top of the Board directory.
+ */
+export function SearchTrigger({
+    target = '/web_view/Search',
+    placeholder = '게시판 / 게시글 검색',
+}: SearchTriggerProps) {
+    const router = useRouter();
+    return (
+        <button
+            type="button"
+            onClick={() => router.push(target)}
+            style={{
+                margin: 'var(--ara-spacing-sm) var(--ara-spacing-lg) var(--ara-spacing-md)',
+                padding: '10px 14px',
+                width: 'calc(100% - 2 * var(--ara-spacing-lg))',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                background: 'var(--ara-bg-muted)',
+                border: 0,
+                borderRadius: 999,
+                color: 'var(--ara-text-tertiary)',
+                fontSize: 14,
+                cursor: 'pointer',
+                textAlign: 'left',
+            }}
+        >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <circle cx="11" cy="11" r="6" stroke="currentColor" strokeWidth="1.8" />
+                <path
+                    d="M20 20L16 16"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                />
+            </svg>
+            <span>{placeholder}</span>
+        </button>
+    );
+}
+
+export function SearchIconButton({ onClick }: { onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            aria-label="검색"
+            onClick={onClick}
+            style={{
+                width: 36,
+                height: 36,
+                background: 'transparent',
+                border: 0,
+                color: 'var(--ara-text-primary)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+            }}
+        >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <circle cx="11" cy="11" r="6" stroke="currentColor" strokeWidth="1.8" />
+                <path
+                    d="M20 20L16 16"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                />
+            </svg>
+        </button>
+    );
+}

--- a/src/app/web_view/Board/page.tsx
+++ b/src/app/web_view/Board/page.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Screen } from '@/app/web_view/_components';
+import { fetchBoardList } from '@/lib/api/board';
+import { BoardHeader } from './_components/BoardHeader';
+import { SearchTrigger } from './_components/SearchTrigger';
+
+// Board entries are typed loosely upstream (`fetchBoardList` returns `any`),
+// so we describe just the fields we touch here.
+interface BoardItem {
+    id: number;
+    slug: string;
+    ko_name: string;
+    en_name?: string;
+    group?: { id: number; ko_name: string; slug: string } | null;
+}
+
+export default function BoardListPage() {
+    const [boards, setBoards] = useState<BoardItem[] | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        fetchBoardList()
+            .then((res) => {
+                // The endpoint returns either an array or a paginated wrapper.
+                const list: BoardItem[] = Array.isArray(res) ? res : (res?.results ?? []);
+                if (!cancelled) setBoards(list);
+            })
+            .catch(() => {
+                if (!cancelled) setBoards([]);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const grouped = useMemo(() => {
+        if (!boards) return null;
+        const map = new Map<string, { name: string; items: BoardItem[] }>();
+        for (const b of boards) {
+            const key = b.group?.slug ?? '__ungrouped';
+            const name = b.group?.ko_name ?? '기타';
+            if (!map.has(key)) map.set(key, { name, items: [] });
+            map.get(key)!.items.push(b);
+        }
+        return Array.from(map.values());
+    }, [boards]);
+
+    return (
+        <Screen>
+            <BoardHeader />
+            <SearchTrigger />
+
+            {grouped === null && <ListSkeleton />}
+            {grouped && grouped.length === 0 && (
+                <div
+                    style={{
+                        padding: 'var(--ara-spacing-xl)',
+                        textAlign: 'center',
+                        color: 'var(--ara-text-tertiary)',
+                    }}
+                >
+                    게시판을 불러올 수 없습니다.
+                </div>
+            )}
+            {grouped &&
+                grouped.map((group) => (
+                    <section key={group.name}>
+                        <div
+                            style={{
+                                padding: '12px var(--ara-spacing-lg) 6px',
+                                fontSize: 13,
+                                fontWeight: 600,
+                                color: 'var(--ara-text-tertiary)',
+                            }}
+                        >
+                            {group.name}
+                        </div>
+                        {group.items.map((board) => (
+                            <Link
+                                key={board.id}
+                                href={`/web_view/Board/${board.slug}`}
+                                className="ara-list-row"
+                                style={{
+                                    textDecoration: 'none',
+                                    color: 'inherit',
+                                    justifyContent: 'space-between',
+                                }}
+                            >
+                                <span
+                                    style={{
+                                        fontSize: 15,
+                                        fontWeight: 500,
+                                        color: 'var(--ara-text-primary)',
+                                    }}
+                                >
+                                    {board.ko_name}
+                                </span>
+                                <ChevronRight />
+                            </Link>
+                        ))}
+                    </section>
+                ))}
+        </Screen>
+    );
+}
+
+function ListSkeleton() {
+    return (
+        <div>
+            {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="ara-list-row">
+                    <div className="ara-skeleton" style={{ height: 16, width: '50%' }} />
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function ChevronRight() {
+    return (
+        <svg
+            width="16"
+            height="16"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden
+            style={{ color: 'var(--ara-text-tertiary)' }}
+        >
+            <path
+                d="M7.5 4L13.5 10L7.5 16"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}

--- a/src/app/web_view/Error/page.tsx
+++ b/src/app/web_view/Error/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Screen } from '@/app/web_view/_components';
+
+export default function ErrorPage() {
+    const onRetry = () => {
+        if (typeof window !== 'undefined') window.location.reload();
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <div
+                style={{
+                    minHeight: '100dvh',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 'var(--ara-spacing-xl)',
+                    gap: 'var(--ara-spacing-lg)',
+                    textAlign: 'center',
+                }}
+            >
+                <h1 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>오류가 발생했어요.</h1>
+                <button
+                    type="button"
+                    onClick={onRetry}
+                    style={{
+                        padding: '12px 24px',
+                        borderRadius: 'var(--ara-radius-md)',
+                        border: '1px solid var(--ara-divider-strong)',
+                        background: 'var(--ara-bg)',
+                        color: 'var(--ara-text-primary)',
+                        fontSize: 14,
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                    }}
+                >
+                    다시 시도
+                </button>
+            </div>
+        </Screen>
+    );
+}

--- a/src/app/web_view/Inquiry/page.tsx
+++ b/src/app/web_view/Inquiry/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { bridge } from '@/app/web_view/_bridge';
+
+export default function InquiryPage() {
+    const onMail = () => {
+        bridge?.send('openExternal', { url: 'mailto:new-ara@sparcs.org' });
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader title="문의" showBack={false} />
+
+            <div
+                style={{
+                    minHeight: 'calc(100dvh - var(--ara-header-height) - var(--ara-safe-top) - var(--ara-safe-bottom))',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 'var(--ara-spacing-xl)',
+                    gap: 'var(--ara-spacing-xl)',
+                    textAlign: 'center',
+                }}
+            >
+                <p
+                    style={{
+                        fontSize: 14,
+                        lineHeight: 1.7,
+                        color: 'var(--ara-text-secondary)',
+                        margin: 0,
+                        maxWidth: 320,
+                    }}
+                >
+                    탈퇴된 계정입니다. 자세한 내용은
+                    <br />
+                    new-ara@sparcs.org 로 문의해 주세요.
+                </p>
+
+                <button
+                    type="button"
+                    onClick={onMail}
+                    style={{
+                        padding: '12px 24px',
+                        borderRadius: 'var(--ara-radius-md)',
+                        border: 0,
+                        background: 'var(--ara-primary)',
+                        color: 'var(--ara-text-on-primary)',
+                        fontSize: 14,
+                        fontWeight: 700,
+                        cursor: 'pointer',
+                    }}
+                >
+                    메일 보내기
+                </button>
+            </div>
+        </Screen>
+    );
+}

--- a/src/app/web_view/Login/page.tsx
+++ b/src/app/web_view/Login/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Screen } from '@/app/web_view/_components';
+
+export default function LoginPage() {
+    const onSsoLogin = () => {
+        const apiHost = process.env.NEXT_PUBLIC_API_HOST || 'https://newara.dev.sparcs.org';
+        const next = encodeURIComponent('https://newara.dev.sparcs.org/web_view/Main');
+        window.location.href = `${apiHost}/api/users/sso_login/?next=${next}`;
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <div
+                style={{
+                    minHeight: '100dvh',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 'var(--ara-spacing-xl)',
+                    gap: 'var(--ara-spacing-xl)',
+                }}
+            >
+                <div style={{ flex: 1 }} />
+                <h1
+                    style={{
+                        fontSize: 48,
+                        fontWeight: 700,
+                        color: 'var(--ara-primary)',
+                        margin: 0,
+                        letterSpacing: 1,
+                    }}
+                >
+                    ARA
+                </h1>
+                <div style={{ flex: 1 }} />
+
+                <button
+                    type="button"
+                    onClick={onSsoLogin}
+                    style={{
+                        width: '100%',
+                        maxWidth: 320,
+                        padding: '14px 20px',
+                        borderRadius: 'var(--ara-radius-md)',
+                        border: 0,
+                        background: 'var(--ara-primary)',
+                        color: 'var(--ara-text-on-primary)',
+                        fontSize: 15,
+                        fontWeight: 700,
+                        cursor: 'pointer',
+                    }}
+                >
+                    SPARCS SSO 로그인
+                </button>
+
+                <footer
+                    style={{
+                        fontSize: 12,
+                        color: 'var(--ara-text-tertiary)',
+                        marginTop: 'var(--ara-spacing-xl)',
+                    }}
+                >
+                    © SPARCS Ara
+                </footer>
+            </div>
+        </Screen>
+    );
+}

--- a/src/app/web_view/Main/_components/HomeHeader.tsx
+++ b/src/app/web_view/Main/_components/HomeHeader.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+/**
+ * Custom large header for the Main (Home) tab. No back button — this is a
+ * tab root. Renders the "ARA" wordmark in brand red and a bell icon that
+ * navigates to the Notifications tab.
+ */
+export function HomeHeader() {
+    const router = useRouter();
+
+    return (
+        <header
+            style={{
+                position: 'sticky',
+                top: 0,
+                zIndex: 40,
+                background: 'var(--ara-bg)',
+                borderBottom: '1px solid var(--ara-divider)',
+                padding: '12px var(--ara-spacing-lg)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+            }}
+        >
+            <h1
+                style={{
+                    margin: 0,
+                    color: 'var(--ara-primary)',
+                    fontSize: 24,
+                    fontWeight: 700,
+                    letterSpacing: 0.5,
+                }}
+            >
+                ARA
+            </h1>
+            <button
+                type="button"
+                aria-label="알림"
+                onClick={() => router.push('/web_view/Notifications')}
+                style={{
+                    width: 36,
+                    height: 36,
+                    background: 'transparent',
+                    border: 0,
+                    color: 'var(--ara-text-primary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: 'pointer',
+                }}
+            >
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+                    <path
+                        d="M6 16V11C6 7.68629 8.68629 5 12 5C15.3137 5 18 7.68629 18 11V16L20 18H4L6 16Z"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinejoin="round"
+                    />
+                    <path
+                        d="M10 21H14"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                    />
+                </svg>
+            </button>
+        </header>
+    );
+}

--- a/src/app/web_view/Main/_components/SectionHeader.tsx
+++ b/src/app/web_view/Main/_components/SectionHeader.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface SectionHeaderProps {
+    title: string;
+    trailing?: ReactNode;
+}
+
+export function SectionHeader({ title, trailing }: SectionHeaderProps) {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '16px var(--ara-spacing-lg) 8px',
+            }}
+        >
+            <h2
+                style={{
+                    margin: 0,
+                    fontSize: 18,
+                    fontWeight: 700,
+                    color: 'var(--ara-text-primary)',
+                }}
+            >
+                {title}
+            </h2>
+            {trailing}
+        </div>
+    );
+}

--- a/src/app/web_view/Main/page.tsx
+++ b/src/app/web_view/Main/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Screen } from '@/app/web_view/_components';
+import { fetchTopArticles, fetchArticles } from '@/lib/api/board';
+import { fetchMe } from '@/lib/api/user';
+import type { ResponsePost } from '@/lib/types/post';
+import { HomeHeader } from './_components/HomeHeader';
+import { SectionHeader } from './_components/SectionHeader';
+import { ArticleRow, ArticleRowSkeleton } from '@/app/web_view/Board/_components/ArticleRow';
+import { Fab } from '@/app/web_view/Board/_components/Fab';
+
+export default function MainPage() {
+    const router = useRouter();
+    const [hot, setHot] = useState<ResponsePost[] | null>(null);
+    const [recent, setRecent] = useState<ResponsePost[] | null>(null);
+    const [authError, setAuthError] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        // Auth gate: bounce to login on 401.
+        fetchMe().catch((err: unknown) => {
+            const status = (err as { response?: { status?: number } })?.response?.status;
+            if (status === 401 && !cancelled) {
+                setAuthError(true);
+                router.replace('/web_view/Login');
+            }
+        });
+
+        // Hot articles preview (top 5).
+        fetchTopArticles({ pageSize: 5 })
+            .then((res) => {
+                if (!cancelled) setHot(res.results ?? []);
+            })
+            .catch(() => {
+                if (!cancelled) setHot([]);
+            });
+
+        // Most recent articles (top 10).
+        fetchArticles({ pageSize: 10, ordering: '-created_at' })
+            .then((res) => {
+                if (!cancelled) setRecent(res.results ?? []);
+            })
+            .catch(() => {
+                if (!cancelled) setRecent([]);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [router]);
+
+    if (authError) {
+        return null;
+    }
+
+    return (
+        <Screen>
+            <HomeHeader />
+
+            <SectionHeader title="🔥 인기 게시물" />
+            <div>
+                {hot === null
+                    ? Array.from({ length: 3 }).map((_, i) => <ArticleRowSkeleton key={i} />)
+                    : hot.length === 0
+                      ? <EmptyMessage text="인기 게시물이 없습니다." />
+                      : hot.map((post, idx) => (
+                            <ArticleRow
+                                key={post.id}
+                                post={post}
+                                rank={idx + 1}
+                                showBoard
+                            />
+                        ))}
+            </div>
+
+            <SectionHeader title="최근 게시물" />
+            <div>
+                {recent === null
+                    ? Array.from({ length: 5 }).map((_, i) => <ArticleRowSkeleton key={i} />)
+                    : recent.length === 0
+                      ? <EmptyMessage text="게시물이 없습니다." />
+                      : recent.map((post) => (
+                            <ArticleRow key={post.id} post={post} showBoard />
+                        ))}
+            </div>
+
+            <Fab href="/web_view/PostWrite" aboveTabBar />
+        </Screen>
+    );
+}
+
+function EmptyMessage({ text }: { text: string }) {
+    return (
+        <div
+            style={{
+                padding: 'var(--ara-spacing-xl)',
+                textAlign: 'center',
+                color: 'var(--ara-text-tertiary)',
+                fontSize: 14,
+            }}
+        >
+            {text}
+        </div>
+    );
+}

--- a/src/app/web_view/MyInfo/BlockedUsers/page.tsx
+++ b/src/app/web_view/MyInfo/BlockedUsers/page.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { deleteBlock, fetchBlocks } from '@/lib/api/user';
+
+interface BlockItem {
+    id: number;
+    blocked_nickname?: string;
+    user?: { nickname?: string } | null;
+    blocked?: { nickname?: string } | null;
+}
+
+function getBlockedName(b: BlockItem): string {
+    return (
+        b.blocked_nickname ?? b.blocked?.nickname ?? b.user?.nickname ?? '알 수 없음'
+    );
+}
+
+export default function BlockedUsersPage() {
+    const [items, setItems] = useState<BlockItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [removing, setRemoving] = useState<number | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            setLoading(true);
+            try {
+                const data = await fetchBlocks();
+                if (cancelled) return;
+                const list = Array.isArray(data) ? data : (data?.results ?? []);
+                setItems(list as BlockItem[]);
+            } catch (e) {
+                console.warn('fetchBlocks failed', e);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const onUnblock = async (id: number) => {
+        if (removing != null) return;
+        setRemoving(id);
+        try {
+            await deleteBlock(id);
+            setItems((prev) => prev.filter((b) => b.id !== id));
+        } catch (e) {
+            console.warn('deleteBlock failed', e);
+        } finally {
+            setRemoving(null);
+        }
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader title="차단된 사용자" />
+
+            {loading ? (
+                <div style={{ padding: 'var(--ara-spacing-lg)' }}>
+                    {[0, 1, 2].map((i) => (
+                        <div
+                            key={i}
+                            className="ara-skeleton"
+                            style={{ height: 48, marginBottom: 8 }}
+                        />
+                    ))}
+                </div>
+            ) : items.length === 0 ? (
+                <div
+                    style={{
+                        padding: '60px 24px',
+                        textAlign: 'center',
+                        color: 'var(--ara-text-secondary)',
+                        fontSize: 13,
+                    }}
+                >
+                    차단된 사용자가 없어요.
+                </div>
+            ) : (
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                    {items.map((b) => (
+                        <li
+                            key={b.id}
+                            className="ara-list-row"
+                            style={{ cursor: 'default' }}
+                        >
+                            <span style={{ flex: 1, fontSize: 14 }}>{getBlockedName(b)}</span>
+                            <button
+                                type="button"
+                                onClick={() => onUnblock(b.id)}
+                                disabled={removing === b.id}
+                                style={{
+                                    padding: '6px 12px',
+                                    borderRadius: 999,
+                                    border: '1px solid var(--ara-divider-strong)',
+                                    background: 'var(--ara-bg)',
+                                    color: 'var(--ara-text-primary)',
+                                    fontSize: 12,
+                                    fontWeight: 600,
+                                    cursor: removing === b.id ? 'default' : 'pointer',
+                                }}
+                            >
+                                {removing === b.id ? '처리 중...' : '차단 해제'}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </Screen>
+    );
+}

--- a/src/app/web_view/MyInfo/Edit/page.tsx
+++ b/src/app/web_view/MyInfo/Edit/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { fetchMe, updateUser } from '@/lib/api/user';
+
+interface MeProfile {
+    id: number;
+    user?: number;
+    nickname?: string;
+    picture?: string | null;
+    see_sexual?: boolean;
+    see_social?: boolean;
+}
+
+export default function ProfileEditPage() {
+    const router = useRouter();
+    const fileRef = useRef<HTMLInputElement | null>(null);
+    const [me, setMe] = useState<MeProfile | null>(null);
+    const [nickname, setNickname] = useState('');
+    const [pictureFile, setPictureFile] = useState<File | null>(null);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        fetchMe()
+            .then((data: MeProfile) => {
+                setMe(data);
+                setNickname(data.nickname ?? '');
+                if (data.picture) setPreviewUrl(data.picture);
+            })
+            .catch((e) => console.warn('fetchMe failed', e));
+    }, []);
+
+    useEffect(() => {
+        if (!pictureFile) return;
+        const url = URL.createObjectURL(pictureFile);
+        setPreviewUrl(url);
+        return () => URL.revokeObjectURL(url);
+    }, [pictureFile]);
+
+    const onPickFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const f = e.target.files?.[0] ?? null;
+        setPictureFile(f);
+    };
+
+    const onSave = async () => {
+        if (!me?.id || saving) return;
+        setSaving(true);
+        try {
+            await updateUser(me.id, {
+                nickname: nickname.trim(),
+                picture: pictureFile,
+                sexual: Boolean(me.see_sexual),
+                social: Boolean(me.see_social),
+            });
+            router.back();
+        } catch (e) {
+            console.warn('updateUser failed', e);
+            alert('저장에 실패했어요. 잠시 후 다시 시도해 주세요.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader title="프로필 수정" />
+
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    padding: 'var(--ara-spacing-xl) var(--ara-spacing-lg)',
+                    gap: 'var(--ara-spacing-md)',
+                }}
+            >
+                <div
+                    style={{
+                        width: 96,
+                        height: 96,
+                        borderRadius: 999,
+                        background: 'var(--ara-bg-muted)',
+                        backgroundImage: previewUrl ? `url(${previewUrl})` : undefined,
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                    }}
+                />
+                <button
+                    type="button"
+                    onClick={() => fileRef.current?.click()}
+                    style={{
+                        background: 'transparent',
+                        border: 0,
+                        color: 'var(--ara-primary)',
+                        fontSize: 13,
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                    }}
+                >
+                    변경
+                </button>
+                <input
+                    ref={fileRef}
+                    type="file"
+                    accept="image/*"
+                    style={{ display: 'none' }}
+                    onChange={onPickFile}
+                />
+            </div>
+
+            <label
+                style={{
+                    display: 'block',
+                    padding: '0 var(--ara-spacing-lg)',
+                    fontSize: 12,
+                    color: 'var(--ara-text-secondary)',
+                    marginBottom: 6,
+                }}
+            >
+                닉네임
+            </label>
+            <div style={{ padding: '0 var(--ara-spacing-lg)' }}>
+                <input
+                    type="text"
+                    value={nickname}
+                    onChange={(e) => setNickname(e.target.value)}
+                    placeholder="닉네임을 입력하세요"
+                    style={{
+                        width: '100%',
+                        padding: '12px 14px',
+                        fontSize: 14,
+                        borderRadius: 'var(--ara-radius-md)',
+                        border: '1px solid var(--ara-divider-strong)',
+                        background: 'var(--ara-bg)',
+                        color: 'var(--ara-text-primary)',
+                        outline: 'none',
+                    }}
+                />
+            </div>
+
+            <div
+                style={{
+                    position: 'fixed',
+                    left: 0,
+                    right: 0,
+                    bottom: 'var(--ara-safe-bottom)',
+                    padding: 'var(--ara-spacing-lg)',
+                    background: 'var(--ara-bg)',
+                    borderTop: '1px solid var(--ara-divider)',
+                }}
+            >
+                <button
+                    type="button"
+                    onClick={onSave}
+                    disabled={saving || !nickname.trim()}
+                    style={{
+                        width: '100%',
+                        padding: '14px',
+                        borderRadius: 'var(--ara-radius-md)',
+                        border: 0,
+                        background: 'var(--ara-primary)',
+                        color: 'var(--ara-text-on-primary)',
+                        fontSize: 15,
+                        fontWeight: 700,
+                        cursor: saving ? 'default' : 'pointer',
+                        opacity: !nickname.trim() ? 0.5 : 1,
+                    }}
+                >
+                    {saving ? '저장 중...' : '저장'}
+                </button>
+            </div>
+        </Screen>
+    );
+}

--- a/src/app/web_view/MyInfo/Settings/page.tsx
+++ b/src/app/web_view/MyInfo/Settings/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { bridge, getBridge } from '@/app/web_view/_bridge';
+import { fetchMe, logout, updateDarkMode } from '@/lib/api/user';
+
+interface MeProfile {
+    id: number;
+    user?: number;
+    extra_preferences?: { darkMode?: boolean } | null;
+}
+
+export default function SettingsPage() {
+    const router = useRouter();
+    const [me, setMe] = useState<MeProfile | null>(null);
+    const [dark, setDark] = useState(false);
+    const [appVersion, setAppVersion] = useState<string>('web');
+
+    useEffect(() => {
+        fetchMe()
+            .then((data: MeProfile) => {
+                setMe(data);
+                setDark(Boolean(data?.extra_preferences?.darkMode));
+            })
+            .catch((e) => console.warn('fetchMe failed', e));
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        getBridge()
+            .ready()
+            .then((cap) => {
+                if (cancelled) return;
+                if (cap?.appVersion) setAppVersion(cap.appVersion);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const onToggleDark = async (next: boolean) => {
+        setDark(next);
+        try {
+            if (me?.id) await updateDarkMode(me.id, next);
+        } catch (e) {
+            console.warn('updateDarkMode failed', e);
+            setDark(!next);
+        }
+    };
+
+    const onMail = () => {
+        bridge?.send('openExternal', { url: 'mailto:new-ara@sparcs.org' });
+    };
+
+    const onLogout = async () => {
+        try {
+            if (me?.user ?? me?.id) await logout((me?.user ?? me?.id) as number);
+        } catch (e) {
+            console.warn('logout failed', e);
+        }
+        try {
+            bridge?.send('clearSession');
+        } catch (e) {
+            console.warn('clearSession failed', e);
+        }
+        router.replace('/web_view/Login');
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader title="설정" />
+
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                <li className="ara-list-row" style={{ cursor: 'default' }}>
+                    <span style={{ flex: 1, fontSize: 14 }}>다크 모드</span>
+                    <Toggle checked={dark} onChange={onToggleDark} />
+                </li>
+                <li
+                    className="ara-list-row"
+                    onClick={() => router.push('/web_view/MyInfo/BlockedUsers')}
+                >
+                    <span style={{ flex: 1, fontSize: 14 }}>차단된 사용자</span>
+                    <Chevron />
+                </li>
+                <li className="ara-list-row" onClick={() => router.push('/web_view/Terms')}>
+                    <span style={{ flex: 1, fontSize: 14 }}>이용약관</span>
+                    <Chevron />
+                </li>
+                <li className="ara-list-row" onClick={onMail}>
+                    <span style={{ flex: 1, fontSize: 14 }}>문의하기</span>
+                    <Chevron />
+                </li>
+                <li className="ara-list-row" style={{ cursor: 'default' }}>
+                    <span style={{ flex: 1, fontSize: 14 }}>버전</span>
+                    <span style={{ color: 'var(--ara-text-tertiary)', fontSize: 13 }}>{appVersion}</span>
+                </li>
+                <li
+                    className="ara-list-row"
+                    onClick={onLogout}
+                    style={{ marginTop: 'var(--ara-spacing-lg)' }}
+                >
+                    <span style={{ flex: 1, fontSize: 14, color: 'var(--ara-primary)', fontWeight: 600 }}>
+                        로그아웃
+                    </span>
+                </li>
+            </ul>
+        </Screen>
+    );
+}
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={checked}
+            onClick={() => onChange(!checked)}
+            style={{
+                width: 40,
+                height: 24,
+                borderRadius: 999,
+                border: 0,
+                background: checked ? 'var(--ara-primary)' : 'var(--ara-divider-strong)',
+                position: 'relative',
+                cursor: 'pointer',
+                transition: 'background 0.15s ease',
+                padding: 0,
+            }}
+        >
+            <span
+                aria-hidden
+                style={{
+                    position: 'absolute',
+                    top: 2,
+                    left: checked ? 18 : 2,
+                    width: 20,
+                    height: 20,
+                    borderRadius: 999,
+                    background: '#FFFFFF',
+                    boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
+                    transition: 'left 0.15s ease',
+                }}
+            />
+        </button>
+    );
+}
+
+function Chevron() {
+    return (
+        <span aria-hidden style={{ color: 'var(--ara-text-tertiary)', fontSize: 18 }}>
+            ›
+        </span>
+    );
+}

--- a/src/app/web_view/MyInfo/page.tsx
+++ b/src/app/web_view/MyInfo/page.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Screen } from '@/app/web_view/_components';
+import { fetchMe } from '@/lib/api/user';
+import { fetchUserPosts } from '@/lib/api/user_profile';
+import { fetchArchivedPosts, fetchRecentViewedPosts } from '@/lib/api/board';
+
+interface MeProfile {
+    id: number;
+    user?: number;
+    nickname?: string;
+    picture?: string | null;
+    email?: string;
+    sso_user_info?: { email?: string; kaist_info?: string } | null;
+}
+
+interface PostRow {
+    id: number;
+    title: string;
+    parent_board?: { ko_name?: string; slug?: string } | null;
+    created_at?: string;
+}
+
+type TabKey = 'mine' | 'scrap' | 'recent';
+
+const TABS: { key: TabKey; label: string }[] = [
+    { key: 'mine', label: '내가 쓴 글' },
+    { key: 'scrap', label: '스크랩한 글' },
+    { key: 'recent', label: '최근 본 글' },
+];
+
+export default function MyInfoPage() {
+    const router = useRouter();
+    const [me, setMe] = useState<MeProfile | null>(null);
+    const [tab, setTab] = useState<TabKey>('mine');
+    const [posts, setPosts] = useState<PostRow[]>([]);
+    const [page, setPage] = useState(1);
+    const [hasNext, setHasNext] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        fetchMe()
+            .then((data) => setMe(data))
+            .catch((e) => console.warn('fetchMe failed', e));
+    }, []);
+
+    const loadPosts = useCallback(
+        async (which: TabKey, p: number) => {
+            setLoading(true);
+            try {
+                let data: { results?: PostRow[]; next?: string | null } = {};
+                if (which === 'mine') {
+                    if (!me?.user && !me?.id) return;
+                    const userId = (me?.user ?? me?.id) as number;
+                    data = await fetchUserPosts(userId, p);
+                } else if (which === 'scrap') {
+                    data = await fetchArchivedPosts({ page: p, pageSize: 20 });
+                } else {
+                    data = await fetchRecentViewedPosts({ page: p, pageSize: 20 });
+                }
+                const results = (data.results ?? []) as PostRow[];
+                setPosts((prev) => (p === 1 ? results : [...prev, ...results]));
+                setHasNext(Boolean(data.next));
+                setPage(p);
+            } catch (e) {
+                console.warn('loadPosts failed', e);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [me],
+    );
+
+    useEffect(() => {
+        if (tab === 'mine' && !me) return;
+        setPosts([]);
+        setHasNext(false);
+        loadPosts(tab, 1);
+    }, [tab, me, loadPosts]);
+
+    const displayName = me?.nickname ?? '익명';
+    const subtitle = me?.email ?? me?.sso_user_info?.email ?? '';
+    const avatar = me?.picture;
+
+    return (
+        <Screen withTabBar="auto">
+            <header style={{ padding: 'var(--ara-spacing-lg) var(--ara-spacing-xl) var(--ara-spacing-md)' }}>
+                <h1 style={{ fontSize: 28, fontWeight: 700, margin: 0 }}>내 정보</h1>
+            </header>
+
+            <section
+                className="ara-card"
+                style={{
+                    margin: '0 var(--ara-spacing-lg) var(--ara-spacing-lg)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 'var(--ara-spacing-lg)',
+                }}
+            >
+                <div
+                    style={{
+                        width: 56,
+                        height: 56,
+                        borderRadius: 999,
+                        background: 'var(--ara-bg-muted)',
+                        backgroundImage: avatar ? `url(${avatar})` : undefined,
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                        flexShrink: 0,
+                    }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--ara-text-primary)' }}>
+                        {displayName}
+                    </div>
+                    {subtitle && (
+                        <div
+                            style={{
+                                fontSize: 12,
+                                color: 'var(--ara-text-secondary)',
+                                marginTop: 2,
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                            }}
+                        >
+                            {subtitle}
+                        </div>
+                    )}
+                </div>
+                <Link
+                    href="/web_view/MyInfo/Edit"
+                    style={{
+                        fontSize: 12,
+                        fontWeight: 600,
+                        padding: '6px 12px',
+                        borderRadius: 999,
+                        border: '1px solid var(--ara-divider-strong)',
+                        color: 'var(--ara-text-primary)',
+                        textDecoration: 'none',
+                        flexShrink: 0,
+                    }}
+                >
+                    프로필 수정
+                </Link>
+            </section>
+
+            <nav
+                role="tablist"
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(3, 1fr)',
+                    margin: '0 var(--ara-spacing-lg) var(--ara-spacing-md)',
+                    background: 'var(--ara-bg-muted)',
+                    borderRadius: 'var(--ara-radius-md)',
+                    padding: 4,
+                    gap: 4,
+                }}
+            >
+                {TABS.map((t) => {
+                    const active = tab === t.key;
+                    return (
+                        <button
+                            key={t.key}
+                            type="button"
+                            role="tab"
+                            aria-selected={active}
+                            onClick={() => setTab(t.key)}
+                            style={{
+                                padding: '8px 4px',
+                                borderRadius: 'var(--ara-radius-sm)',
+                                border: 0,
+                                fontSize: 13,
+                                fontWeight: active ? 700 : 500,
+                                color: active ? 'var(--ara-text-primary)' : 'var(--ara-text-secondary)',
+                                background: active ? 'var(--ara-bg)' : 'transparent',
+                                cursor: 'pointer',
+                                boxShadow: active ? '0 1px 2px rgba(0,0,0,0.06)' : 'none',
+                            }}
+                        >
+                            {t.label}
+                        </button>
+                    );
+                })}
+            </nav>
+
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                {posts.map((p) => (
+                    <li
+                        key={p.id}
+                        className="ara-list-row"
+                        onClick={() => router.push(`/web_view/Post/${p.id}`)}
+                    >
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <div
+                                style={{
+                                    fontSize: 14,
+                                    fontWeight: 500,
+                                    color: 'var(--ara-text-primary)',
+                                    whiteSpace: 'nowrap',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                }}
+                            >
+                                {p.title}
+                            </div>
+                            {p.parent_board?.ko_name && (
+                                <div
+                                    style={{
+                                        fontSize: 11,
+                                        color: 'var(--ara-text-tertiary)',
+                                        marginTop: 2,
+                                    }}
+                                >
+                                    {p.parent_board.ko_name}
+                                </div>
+                            )}
+                        </div>
+                    </li>
+                ))}
+            </ul>
+
+            {!loading && posts.length === 0 && (
+                <div
+                    style={{
+                        textAlign: 'center',
+                        color: 'var(--ara-text-secondary)',
+                        padding: '40px 16px',
+                        fontSize: 13,
+                    }}
+                >
+                    아직 게시글이 없어요.
+                </div>
+            )}
+
+            {hasNext && (
+                <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--ara-spacing-md)' }}>
+                    <button
+                        type="button"
+                        onClick={() => loadPosts(tab, page + 1)}
+                        disabled={loading}
+                        style={{
+                            padding: '8px 18px',
+                            borderRadius: 'var(--ara-radius-md)',
+                            border: '1px solid var(--ara-divider-strong)',
+                            background: 'var(--ara-bg)',
+                            color: 'var(--ara-text-primary)',
+                            fontSize: 13,
+                            cursor: loading ? 'default' : 'pointer',
+                        }}
+                    >
+                        {loading ? '불러오는 중...' : '더 보기'}
+                    </button>
+                </div>
+            )}
+
+            <div
+                className="ara-list-row"
+                onClick={() => router.push('/web_view/MyInfo/Settings')}
+                style={{ marginTop: 'var(--ara-spacing-lg)', borderTop: '1px solid var(--ara-divider)' }}
+            >
+                <span style={{ flex: 1, fontSize: 14, fontWeight: 500 }}>설정</span>
+                <span style={{ color: 'var(--ara-text-tertiary)', fontSize: 18 }}>›</span>
+            </div>
+        </Screen>
+    );
+}

--- a/src/app/web_view/Notifications/page.tsx
+++ b/src/app/web_view/Notifications/page.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Screen } from '@/app/web_view/_components';
+import { fetchNotifications, readAllNotifications } from '@/lib/api/notification';
+
+interface NotificationItem {
+    id: number;
+    type: string;
+    title: string;
+    content: string;
+    is_read: boolean;
+    created_at: string;
+    related_article?: { id: number } | null;
+    related?: { parent_article?: number | null } | null;
+}
+
+function relativeTime(iso: string): string {
+    if (!iso) return '';
+    const then = new Date(iso).getTime();
+    if (isNaN(then)) return '';
+    const diff = Math.max(0, Date.now() - then);
+    const m = Math.floor(diff / 60000);
+    if (m < 1) return '방금 전';
+    if (m < 60) return `${m}분 전`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}시간 전`;
+    const d = Math.floor(h / 24);
+    if (d < 7) return `${d}일 전`;
+    const w = Math.floor(d / 7);
+    if (w < 4) return `${w}주 전`;
+    const mo = Math.floor(d / 30);
+    if (mo < 12) return `${mo}달 전`;
+    const y = Math.floor(d / 365);
+    return `${y}년 전`;
+}
+
+function getTargetArticleId(n: NotificationItem): number | null {
+    if (n.related?.parent_article != null) return Number(n.related.parent_article);
+    if (n.related_article?.id != null) return Number(n.related_article.id);
+    return null;
+}
+
+export default function NotificationsPage() {
+    const router = useRouter();
+    const [items, setItems] = useState<NotificationItem[]>([]);
+    const [page, setPage] = useState(1);
+    const [hasNext, setHasNext] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [markingAll, setMarkingAll] = useState(false);
+
+    const loadPage = useCallback(async (p: number) => {
+        setLoading(true);
+        try {
+            const data = await fetchNotifications(p, 20);
+            const results = (data?.results ?? []) as NotificationItem[];
+            setItems((prev) => (p === 1 ? results : [...prev, ...results]));
+            setHasNext(Boolean(data?.next));
+            setPage(p);
+        } catch (e) {
+            console.warn('fetchNotifications failed', e);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadPage(1);
+    }, [loadPage]);
+
+    const onReadAll = async () => {
+        if (markingAll) return;
+        setMarkingAll(true);
+        try {
+            await readAllNotifications();
+            setItems((prev) => prev.map((it) => ({ ...it, is_read: true })));
+        } catch (e) {
+            console.warn('readAllNotifications failed', e);
+        } finally {
+            setMarkingAll(false);
+        }
+    };
+
+    const onTap = (n: NotificationItem) => {
+        const articleId = getTargetArticleId(n);
+        if (articleId) router.push(`/web_view/Post/${articleId}`);
+    };
+
+    return (
+        <Screen withTabBar="auto">
+            <header
+                style={{
+                    display: 'flex',
+                    alignItems: 'flex-end',
+                    justifyContent: 'space-between',
+                    padding: 'var(--ara-spacing-lg) var(--ara-spacing-xl) var(--ara-spacing-md)',
+                }}
+            >
+                <h1 style={{ fontSize: 28, fontWeight: 700, margin: 0 }}>알림</h1>
+                <button
+                    type="button"
+                    onClick={onReadAll}
+                    disabled={markingAll || items.length === 0}
+                    style={{
+                        background: 'transparent',
+                        border: 0,
+                        color: 'var(--ara-primary)',
+                        fontSize: 14,
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        padding: 4,
+                    }}
+                >
+                    전체 읽음
+                </button>
+            </header>
+
+            {!loading && items.length === 0 ? (
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        padding: '80px 24px',
+                        color: 'var(--ara-text-secondary)',
+                    }}
+                >
+                    새 알림이 없어요.
+                </div>
+            ) : (
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                    {items.map((n) => (
+                        <li
+                            key={n.id}
+                            className="ara-list-row"
+                            onClick={() => onTap(n)}
+                            style={{ alignItems: 'flex-start', gap: 'var(--ara-spacing-sm)' }}
+                        >
+                            <span
+                                aria-hidden
+                                style={{
+                                    width: 8,
+                                    height: 8,
+                                    borderRadius: 999,
+                                    marginTop: 8,
+                                    flexShrink: 0,
+                                    background: n.is_read ? 'transparent' : 'var(--ara-primary)',
+                                }}
+                            />
+                            <div style={{ flex: 1, minWidth: 0 }}>
+                                <div
+                                    style={{
+                                        fontSize: 14,
+                                        fontWeight: 600,
+                                        color: 'var(--ara-text-primary)',
+                                        whiteSpace: 'nowrap',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                    }}
+                                >
+                                    {n.title}
+                                </div>
+                                <div
+                                    style={{
+                                        fontSize: 13,
+                                        color: 'var(--ara-text-secondary)',
+                                        whiteSpace: 'nowrap',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        marginTop: 2,
+                                    }}
+                                >
+                                    {n.content}
+                                </div>
+                            </div>
+                            <span
+                                style={{
+                                    fontSize: 11,
+                                    color: 'var(--ara-text-tertiary)',
+                                    flexShrink: 0,
+                                    marginLeft: 'var(--ara-spacing-sm)',
+                                }}
+                            >
+                                {relativeTime(n.created_at)}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {hasNext && items.length > 0 && (
+                <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--ara-spacing-lg)' }}>
+                    <button
+                        type="button"
+                        onClick={() => loadPage(page + 1)}
+                        disabled={loading}
+                        style={{
+                            padding: '10px 20px',
+                            borderRadius: 'var(--ara-radius-md)',
+                            border: '1px solid var(--ara-divider-strong)',
+                            background: 'var(--ara-bg)',
+                            color: 'var(--ara-text-primary)',
+                            fontSize: 13,
+                            fontWeight: 500,
+                            cursor: loading ? 'default' : 'pointer',
+                        }}
+                    >
+                        {loading ? '불러오는 중...' : '더 보기'}
+                    </button>
+                </div>
+            )}
+
+            {loading && items.length === 0 && (
+                <div style={{ padding: 'var(--ara-spacing-lg)' }}>
+                    {[0, 1, 2, 3].map((i) => (
+                        <div
+                            key={i}
+                            className="ara-skeleton"
+                            style={{ height: 56, marginBottom: 8 }}
+                        />
+                    ))}
+                </div>
+            )}
+        </Screen>
+    );
+}

--- a/src/app/web_view/Post/[id]/_components/ArticleHeader.tsx
+++ b/src/app/web_view/Post/[id]/_components/ArticleHeader.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { formatDate } from '@/app/post/util/formatDate';
+import type { PostData } from '@/lib/types/post';
+
+interface ArticleHeaderProps {
+    post: PostData;
+}
+
+/**
+ * Top section of the post detail screen: board/topic pill, title, author row,
+ * date, view count, and comment count.
+ */
+export function ArticleHeader({ post }: ArticleHeaderProps) {
+    const router = useRouter();
+
+    // name_type === 1 means nickname is shown (clickable profile).
+    const isAnonymous = post.name_type !== 1;
+    const board = post.parent_board?.ko_name ?? '';
+    // ParseTopic — the `parent_topic` field is on the article when present.
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const topic = (post as any)?.parent_topic?.ko_name ?? '';
+
+    const onAuthorClick = () => {
+        if (isAnonymous) return;
+        router.push(`/web_view/User/${post.created_by.id}`);
+    };
+
+    return (
+        <section
+            style={{
+                padding: '16px var(--ara-spacing-lg)',
+                borderBottom: '1px solid var(--ara-divider)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+            }}
+        >
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {board && <span className="ara-pill">{board}</span>}
+                {topic && <span className="ara-pill ara-pill--primary">{topic}</span>}
+            </div>
+
+            <h2
+                style={{
+                    margin: 0,
+                    fontSize: 18,
+                    fontWeight: 700,
+                    lineHeight: 1.4,
+                    color: 'var(--ara-text-primary)',
+                    wordBreak: 'break-word',
+                }}
+            >
+                {post.title}
+            </h2>
+
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    flexWrap: 'wrap',
+                    fontSize: 12,
+                    color: 'var(--ara-text-tertiary)',
+                }}
+            >
+                <span
+                    onClick={onAuthorClick}
+                    role={isAnonymous ? undefined : 'button'}
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        color: 'var(--ara-text-secondary)',
+                        cursor: isAnonymous ? 'default' : 'pointer',
+                    }}
+                >
+                    {post.created_by?.profile?.picture && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                            src={post.created_by.profile.picture}
+                            alt=""
+                            width={20}
+                            height={20}
+                            style={{ borderRadius: '50%', objectFit: 'cover' }}
+                        />
+                    )}
+                    <span>{post.created_by?.profile?.nickname ?? ''}</span>
+                </span>
+                <span aria-hidden>·</span>
+                <span>{formatDate(post.created_at)}</span>
+                <span aria-hidden>·</span>
+                <span>조회 {post.hit_count ?? 0}</span>
+                <span aria-hidden>·</span>
+                <span>댓글 {post.comments?.length ?? 0}</span>
+            </div>
+        </section>
+    );
+}

--- a/src/app/web_view/Post/[id]/_components/Attachments.tsx
+++ b/src/app/web_view/Post/[id]/_components/Attachments.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { bridge } from '@/app/web_view/_bridge';
+
+type RawAttachment = {
+    id: number;
+    file: string;
+    mimetype: string;
+    size?: number;
+};
+
+interface AttachmentsProps {
+    attachments: RawAttachment[];
+}
+
+const isImage = (mimetype: string) => mimetype?.startsWith('image');
+
+/**
+ * Renders inline images and a download card per non-image attachment.
+ * Uses the bridge `openExternal` for downloads when available; otherwise
+ * just opens in a new tab.
+ */
+export function Attachments({ attachments }: AttachmentsProps) {
+    if (!attachments?.length) return null;
+
+    const images = attachments.filter((a) => isImage(a.mimetype));
+    const files = attachments.filter((a) => !isImage(a.mimetype));
+
+    const open = (url: string) => {
+        try {
+            bridge?.send('openExternal', { url });
+        } catch {
+            if (typeof window !== 'undefined') window.open(url, '_blank');
+        }
+    };
+
+    return (
+        <div style={{ padding: '0 var(--ara-spacing-lg)', display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {images.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {images.map((img) => (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                            key={img.id}
+                            src={img.file}
+                            alt=""
+                            style={{
+                                width: '100%',
+                                borderRadius: 'var(--ara-radius-md)',
+                                objectFit: 'contain',
+                            }}
+                        />
+                    ))}
+                </div>
+            )}
+
+            {files.length > 0 && (
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {files.map((f) => {
+                        const name = f.file.split('/').pop() ?? 'attachment';
+                        return (
+                            <li
+                                key={f.id}
+                                onClick={() => open(f.file)}
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 10,
+                                    padding: 12,
+                                    border: '1px solid var(--ara-divider)',
+                                    borderRadius: 'var(--ara-radius-md)',
+                                    background: 'var(--ara-bg-muted)',
+                                    cursor: 'pointer',
+                                }}
+                            >
+                                <span aria-hidden style={{ fontSize: 18 }}>📎</span>
+                                <span
+                                    style={{
+                                        flex: 1,
+                                        fontSize: 13,
+                                        color: 'var(--ara-text-primary)',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                    title={name}
+                                >
+                                    {name}
+                                </span>
+                                <span style={{ fontSize: 12, color: 'var(--ara-text-tertiary)' }}>다운로드</span>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/src/app/web_view/Post/[id]/_components/CommentComposer.tsx
+++ b/src/app/web_view/Post/[id]/_components/CommentComposer.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import http from '@/lib/api/http';
+import { bridge } from '@/app/web_view/_bridge';
+import { StickyComposer } from '@/app/web_view/_components';
+
+interface CommentComposerProps {
+    postId: number;
+    /** Bitmask: 1 = nickname allowed, 2 = anonymous allowed. */
+    allowedNameTypes: number;
+    /** When set, posts a reply to this comment id. */
+    replyToCommentId?: number | null;
+    onCancelReply?: () => void;
+    onPosted?: () => void;
+}
+
+const MAX_LINE_HEIGHT_PX = 22; // matches font-size 14 with 1.5 line-height
+const MAX_LINES = 5;
+
+/**
+ * Sticky bottom comment composer. Auto-grows up to 5 lines and rides above
+ * the software keyboard via StickyComposer's `--ara-keyboard-height`.
+ */
+export function CommentComposer({
+    postId,
+    allowedNameTypes,
+    replyToCommentId,
+    onCancelReply,
+    onPosted,
+}: CommentComposerProps) {
+    const canNickname = (allowedNameTypes & 1) > 0;
+    const canAnonymous = (allowedNameTypes & 2) > 0;
+
+    const [text, setText] = useState('');
+    const [anonymous, setAnonymous] = useState<boolean>(canAnonymous && !canNickname);
+    const [submitting, setSubmitting] = useState(false);
+    const taRef = useRef<HTMLTextAreaElement>(null);
+
+    // Auto-grow up to MAX_LINES.
+    useEffect(() => {
+        const el = taRef.current;
+        if (!el) return;
+        el.style.height = 'auto';
+        const max = MAX_LINE_HEIGHT_PX * MAX_LINES + 16; // + vertical padding
+        el.style.height = `${Math.min(el.scrollHeight, max)}px`;
+        el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
+    }, [text]);
+
+    const showAnonymousToggle = canNickname && canAnonymous;
+    const disabled = !text.trim() || submitting;
+
+    const submit = async () => {
+        if (disabled) return;
+        try {
+            bridge?.send('haptic', { kind: 'light' });
+        } catch {
+            /* noop */
+        }
+        setSubmitting(true);
+        try {
+            const nameType = anonymous ? 2 : 1;
+            const body: Record<string, unknown> = {
+                content: text,
+                name_type: nameType,
+                attachment: null,
+            };
+            if (replyToCommentId) body.parent_comment = replyToCommentId;
+            else body.parent_article = postId;
+            await http.post('comments/', body);
+            setText('');
+            taRef.current?.blur();
+            onPosted?.();
+        } catch (e) {
+            console.error('createComment failed', e);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <StickyComposer aboveTabBar={false}>
+            {replyToCommentId && (
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        padding: '6px 12px 0',
+                        fontSize: 12,
+                        color: 'var(--ara-text-tertiary)',
+                    }}
+                >
+                    <span>답글 작성 중</span>
+                    {onCancelReply && (
+                        <button
+                            type="button"
+                            onClick={onCancelReply}
+                            style={{
+                                background: 'transparent',
+                                border: 0,
+                                color: 'var(--ara-text-secondary)',
+                                fontSize: 12,
+                                cursor: 'pointer',
+                                padding: 0,
+                            }}
+                        >
+                            취소
+                        </button>
+                    )}
+                </div>
+            )}
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'flex-end',
+                    gap: 8,
+                    padding: '8px 12px',
+                }}
+            >
+                {showAnonymousToggle && (
+                    <button
+                        type="button"
+                        role="switch"
+                        aria-checked={anonymous}
+                        onClick={() => setAnonymous((v) => !v)}
+                        style={{
+                            flexShrink: 0,
+                            height: 32,
+                            padding: '0 10px',
+                            borderRadius: 999,
+                            border: `1px solid ${anonymous ? 'var(--ara-primary)' : 'var(--ara-divider-strong)'}`,
+                            background: anonymous ? 'var(--ara-primary-bright)' : 'transparent',
+                            color: anonymous ? 'var(--ara-primary)' : 'var(--ara-text-secondary)',
+                            fontSize: 12,
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                        }}
+                    >
+                        익명
+                    </button>
+                )}
+                <textarea
+                    ref={taRef}
+                    value={text}
+                    onChange={(e) => setText(e.target.value)}
+                    placeholder="댓글을 입력하세요"
+                    rows={1}
+                    inputMode="text"
+                    autoCapitalize="sentences"
+                    style={{
+                        flex: 1,
+                        minHeight: 36,
+                        maxHeight: MAX_LINE_HEIGHT_PX * MAX_LINES + 16,
+                        padding: '8px 12px',
+                        borderRadius: 18,
+                        border: '1px solid var(--ara-divider-strong)',
+                        background: 'var(--ara-bg-muted)',
+                        fontSize: 14,
+                        lineHeight: '22px',
+                        color: 'var(--ara-text-primary)',
+                        resize: 'none',
+                        outline: 'none',
+                        fontFamily: 'inherit',
+                    }}
+                />
+                <button
+                    type="button"
+                    onClick={submit}
+                    disabled={disabled}
+                    style={{
+                        flexShrink: 0,
+                        height: 36,
+                        padding: '0 14px',
+                        borderRadius: 18,
+                        border: 0,
+                        background: disabled ? 'var(--ara-divider-strong)' : 'var(--ara-primary)',
+                        color: '#fff',
+                        fontSize: 14,
+                        fontWeight: 600,
+                        cursor: disabled ? 'not-allowed' : 'pointer',
+                    }}
+                >
+                    전송
+                </button>
+            </div>
+        </StickyComposer>
+    );
+}

--- a/src/app/web_view/Post/[id]/_components/CommentItem.tsx
+++ b/src/app/web_view/Post/[id]/_components/CommentItem.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useState } from 'react';
+import { formatDate } from '@/app/post/util/formatDate';
+import { voteComment } from '@/lib/api/post';
+import { bridge } from '@/app/web_view/_bridge';
+import type { Comment, CommentNested } from '@/lib/types/post';
+
+interface CommentItemProps {
+    comment: Comment | CommentNested;
+    nested?: boolean;
+    onReply?: (parentId: number, defaultName: number) => void;
+    onChanged?: () => void;
+}
+
+const ANONYMOUS_NICK = '익명';
+
+function nickFor(c: Comment | CommentNested): string {
+    if (c.name_type === 2) return ANONYMOUS_NICK;
+    return c.created_by?.profile?.nickname ?? '';
+}
+
+function avatarLetter(nick: string): string {
+    return nick?.[0] ?? '?';
+}
+
+export function CommentItem({ comment, nested = false, onReply, onChanged }: CommentItemProps) {
+    const [myVote, setMyVote] = useState<boolean | null>(comment.my_vote);
+    const [pos, setPos] = useState<number>(comment.positive_vote_count ?? 0);
+    const [neg, setNeg] = useState<number>(comment.negative_vote_count ?? 0);
+
+    const tap = () => {
+        try {
+            bridge?.send('haptic', { kind: 'light' });
+        } catch {
+            /* noop */
+        }
+    };
+
+    const handleVote = async (positive: boolean) => {
+        tap();
+        const action: 'vote_positive' | 'vote_negative' | 'vote_cancel' =
+            positive ? (myVote === true ? 'vote_cancel' : 'vote_positive')
+                     : (myVote === false ? 'vote_cancel' : 'vote_negative');
+        const prev = { myVote, pos, neg };
+        // Optimistic update
+        let nMy: boolean | null = myVote;
+        let nPos = pos;
+        let nNeg = neg;
+        if (action === 'vote_positive') {
+            nMy = true;
+            nPos += 1;
+            if (myVote === false) nNeg -= 1;
+        } else if (action === 'vote_negative') {
+            nMy = false;
+            nNeg += 1;
+            if (myVote === true) nPos -= 1;
+        } else {
+            if (myVote === true) nPos -= 1;
+            if (myVote === false) nNeg -= 1;
+            nMy = null;
+        }
+        setMyVote(nMy);
+        setPos(nPos);
+        setNeg(nNeg);
+        try {
+            await voteComment(comment.id, action);
+            onChanged?.();
+        } catch (e) {
+            console.error('voteComment failed', e);
+            setMyVote(prev.myVote);
+            setPos(prev.pos);
+            setNeg(prev.neg);
+        }
+    };
+
+    const isDeleted = !!comment.deleted_at;
+    const nick = nickFor(comment);
+    const replies = (comment as Comment).comments;
+
+    return (
+        <div
+            style={{
+                padding: '12px var(--ara-spacing-lg)',
+                paddingLeft: nested ? 'calc(var(--ara-spacing-lg) + 24px)' : 'var(--ara-spacing-lg)',
+                borderBottom: nested ? 'none' : '1px solid var(--ara-divider)',
+                background: nested ? 'var(--ara-bg-muted)' : 'var(--ara-bg)',
+            }}
+        >
+            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                <div
+                    aria-hidden
+                    style={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: '50%',
+                        background: 'var(--ara-bg-muted)',
+                        color: 'var(--ara-text-secondary)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: 12,
+                        fontWeight: 600,
+                        flexShrink: 0,
+                    }}
+                >
+                    {avatarLetter(nick)}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                        style={{
+                            display: 'flex',
+                            gap: 6,
+                            alignItems: 'center',
+                            fontSize: 12,
+                            color: 'var(--ara-text-tertiary)',
+                            marginBottom: 4,
+                        }}
+                    >
+                        <span style={{ color: 'var(--ara-text-secondary)', fontWeight: 600 }}>{nick}</span>
+                        <span aria-hidden>·</span>
+                        <span>{formatDate(comment.created_at)}</span>
+                    </div>
+                    <p
+                        style={{
+                            margin: 0,
+                            fontSize: 14,
+                            lineHeight: 1.5,
+                            color: isDeleted ? 'var(--ara-text-tertiary)' : 'var(--ara-text-primary)',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
+                        }}
+                    >
+                        {isDeleted ? '삭제된 댓글입니다.' : comment.content}
+                    </p>
+
+                    {!isDeleted && (
+                        <div
+                            style={{
+                                display: 'flex',
+                                gap: 12,
+                                alignItems: 'center',
+                                marginTop: 6,
+                                fontSize: 12,
+                                color: 'var(--ara-text-tertiary)',
+                            }}
+                        >
+                            <button
+                                type="button"
+                                onClick={() => handleVote(true)}
+                                style={voteBtnStyle(myVote === true, 'pos')}
+                            >
+                                <Arrow direction="up" /> {pos}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleVote(false)}
+                                style={voteBtnStyle(myVote === false, 'neg')}
+                            >
+                                <Arrow direction="down" /> {neg}
+                            </button>
+                            {!nested && onReply && (
+                                <button
+                                    type="button"
+                                    onClick={() => onReply(comment.id, comment.name_type)}
+                                    style={{
+                                        background: 'transparent',
+                                        border: 0,
+                                        color: 'var(--ara-text-secondary)',
+                                        fontSize: 12,
+                                        cursor: 'pointer',
+                                        padding: 0,
+                                    }}
+                                >
+                                    답글
+                                </button>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {replies && replies.length > 0 && (
+                <div style={{ marginTop: 8 }}>
+                    {replies.map((r) => (
+                        <CommentItem key={r.id} comment={r} nested onChanged={onChanged} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function voteBtnStyle(active: boolean, kind: 'pos' | 'neg'): React.CSSProperties {
+    const color = active ? (kind === 'pos' ? 'var(--ara-positive)' : 'var(--ara-negative)') : 'var(--ara-text-tertiary)';
+    return {
+        background: 'transparent',
+        border: 0,
+        color,
+        fontSize: 12,
+        cursor: 'pointer',
+        padding: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+    };
+}
+
+function Arrow({ direction }: { direction: 'up' | 'down' }) {
+    const rotate = direction === 'up' ? 0 : 180;
+    return (
+        <svg width="10" height="10" viewBox="0 0 14 14" fill="none" style={{ transform: `rotate(${rotate}deg)` }} aria-hidden>
+            <path d="M7 3L11.5 9.5H2.5L7 3Z" fill="currentColor" />
+        </svg>
+    );
+}

--- a/src/app/web_view/Post/[id]/_components/MoreButton.tsx
+++ b/src/app/web_view/Post/[id]/_components/MoreButton.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { bridge } from '@/app/web_view/_bridge';
+
+interface MoreButtonProps {
+    /** Absolute URL (or path) to share / copy. */
+    shareUrl?: string;
+    onReport?: () => void;
+    onBlock?: () => void;
+}
+
+/**
+ * Kebab button for the post detail header. Opens a small popover with
+ * 신고 / 차단 / 공유 actions. Share goes through the native bridge when
+ * available, falling back to clipboard.
+ */
+export function MoreButton({ shareUrl, onReport, onBlock }: MoreButtonProps) {
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        const handleClick = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClick);
+        return () => document.removeEventListener('mousedown', handleClick);
+    }, [open]);
+
+    const tap = () => {
+        try {
+            bridge?.send('haptic', { kind: 'light' });
+        } catch {
+            /* noop */
+        }
+    };
+
+    const handleShare = async () => {
+        tap();
+        setOpen(false);
+        const url = shareUrl ?? (typeof window !== 'undefined' ? window.location.href : '');
+        try {
+            // Prefer native share. If unsupported, fall back to clipboard.
+            const res = await bridge?.request('share', { url });
+            if (res && !res.shared) {
+                bridge?.send('clipboardWrite', { text: url });
+            }
+        } catch {
+            try {
+                bridge?.send('clipboardWrite', { text: url });
+            } catch {
+                console.log('[MoreButton] share fallback failed', url);
+            }
+        }
+    };
+
+    const handleReport = () => {
+        tap();
+        setOpen(false);
+        if (onReport) onReport();
+        else console.log('[MoreButton] report stub');
+    };
+
+    const handleBlock = () => {
+        tap();
+        setOpen(false);
+        if (onBlock) onBlock();
+        else console.log('[MoreButton] block stub');
+    };
+
+    return (
+        <div ref={ref} style={{ position: 'relative' }}>
+            <button
+                type="button"
+                className="ara-header__btn"
+                aria-label="more"
+                onClick={() => setOpen((v) => !v)}
+            >
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+                    <circle cx="10" cy="4.5" r="1.5" fill="currentColor" />
+                    <circle cx="10" cy="10" r="1.5" fill="currentColor" />
+                    <circle cx="10" cy="15.5" r="1.5" fill="currentColor" />
+                </svg>
+            </button>
+            {open && (
+                <div
+                    role="menu"
+                    style={{
+                        position: 'absolute',
+                        top: 'calc(100% + 4px)',
+                        right: 0,
+                        minWidth: 140,
+                        background: 'var(--ara-bg-elevated)',
+                        border: '1px solid var(--ara-divider)',
+                        borderRadius: 'var(--ara-radius-md)',
+                        boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
+                        overflow: 'hidden',
+                        zIndex: 60,
+                    }}
+                >
+                    <MenuItem label="신고" onClick={handleReport} />
+                    <MenuItem label="차단" onClick={handleBlock} />
+                    <MenuItem label="공유" onClick={handleShare} />
+                </div>
+            )}
+        </div>
+    );
+}
+
+function MenuItem({ label, onClick }: { label: string; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            role="menuitem"
+            onClick={onClick}
+            style={{
+                display: 'block',
+                width: '100%',
+                padding: '10px 14px',
+                textAlign: 'left',
+                background: 'transparent',
+                border: 0,
+                fontSize: 14,
+                color: 'var(--ara-text-primary)',
+                cursor: 'pointer',
+            }}
+        >
+            {label}
+        </button>
+    );
+}

--- a/src/app/web_view/Post/[id]/_components/VoteRow.tsx
+++ b/src/app/web_view/Post/[id]/_components/VoteRow.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { bridge } from '@/app/web_view/_bridge';
+
+interface VoteRowProps {
+    myVote: boolean | null;
+    positive: number;
+    negative: number;
+    onVote: (action: 'vote_positive' | 'vote_negative' | 'vote_cancel') => void;
+}
+
+/**
+ * Up/down arrow + count pair shown below the article body.
+ */
+export function VoteRow({ myVote, positive, negative, onVote }: VoteRowProps) {
+    const tap = () => {
+        try {
+            bridge?.send('haptic', { kind: 'light' });
+        } catch {
+            /* noop */
+        }
+    };
+
+    const handleUp = () => {
+        tap();
+        onVote(myVote === true ? 'vote_cancel' : 'vote_positive');
+    };
+    const handleDown = () => {
+        tap();
+        onVote(myVote === false ? 'vote_cancel' : 'vote_negative');
+    };
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                gap: 12,
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '12px 0',
+            }}
+        >
+            <button
+                type="button"
+                onClick={handleUp}
+                aria-pressed={myVote === true}
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '8px 14px',
+                    border: `1px solid ${myVote === true ? 'var(--ara-positive)' : 'var(--ara-divider-strong)'}`,
+                    borderRadius: 999,
+                    background: myVote === true ? 'var(--ara-primary-bright)' : 'transparent',
+                    color: myVote === true ? 'var(--ara-positive)' : 'var(--ara-text-secondary)',
+                    fontSize: 14,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                }}
+            >
+                <Arrow direction="up" />
+                {positive}
+            </button>
+            <button
+                type="button"
+                onClick={handleDown}
+                aria-pressed={myVote === false}
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '8px 14px',
+                    border: `1px solid ${myVote === false ? 'var(--ara-negative)' : 'var(--ara-divider-strong)'}`,
+                    borderRadius: 999,
+                    background: myVote === false ? '#EAF2FB' : 'transparent',
+                    color: myVote === false ? 'var(--ara-negative)' : 'var(--ara-text-secondary)',
+                    fontSize: 14,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                }}
+            >
+                <Arrow direction="down" />
+                {negative}
+            </button>
+        </div>
+    );
+}
+
+function Arrow({ direction }: { direction: 'up' | 'down' }) {
+    const rotate = direction === 'up' ? 0 : 180;
+    return (
+        <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            style={{ transform: `rotate(${rotate}deg)` }}
+            aria-hidden
+        >
+            <path
+                d="M7 3L11.5 9.5H2.5L7 3Z"
+                fill="currentColor"
+            />
+        </svg>
+    );
+}

--- a/src/app/web_view/Post/[id]/page.tsx
+++ b/src/app/web_view/Post/[id]/page.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { fetchPost, votePost } from '@/lib/api/post';
+import { formatPost } from '@/app/post/util/getPost';
+import TextEditor from '@/components/TextEditor/TextEditor';
+import type { PostData } from '@/lib/types/post';
+import { Screen, AppHeader, ComposerSpacer } from '@/app/web_view/_components';
+import { MoreButton } from './_components/MoreButton';
+import { ArticleHeader } from './_components/ArticleHeader';
+import { VoteRow } from './_components/VoteRow';
+import { Attachments } from './_components/Attachments';
+import { CommentItem } from './_components/CommentItem';
+import { CommentComposer } from './_components/CommentComposer';
+import { apiUrl } from '@/lib/api/http';
+
+type VoteAction = 'vote_positive' | 'vote_negative' | 'vote_cancel';
+
+export default function WebViewPostDetailPage() {
+    const params = useParams();
+    const router = useRouter();
+    const idRaw = (params?.id ?? '') as string;
+    const postId = Number.parseInt(idRaw, 10);
+
+    const [post, setPost] = useState<PostData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [replyTarget, setReplyTarget] = useState<number | null>(null);
+
+    const load = useCallback(async () => {
+        if (!Number.isFinite(postId) || postId <= 0) {
+            setError('잘못된 게시물 주소입니다.');
+            setLoading(false);
+            return;
+        }
+        try {
+            const data = await fetchPost({
+                postId,
+                fromView: 'all',
+                current: 3,
+                overrideHidden: true,
+            });
+            setPost(formatPost({ data }) as unknown as PostData);
+            setError(null);
+        } catch (e) {
+            console.error('fetchPost failed', e);
+            setError('게시물을 불러오지 못했습니다.');
+        } finally {
+            setLoading(false);
+        }
+    }, [postId]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const applyVote = (action: VoteAction) => {
+        setPost((prev) => {
+            if (!prev) return prev;
+            let pos = prev.positive_vote_count;
+            let neg = prev.negative_vote_count;
+            let next: boolean | null = prev.my_vote;
+            if (action === 'vote_positive') {
+                next = true;
+                pos += 1;
+                if (prev.my_vote === false) neg -= 1;
+            } else if (action === 'vote_negative') {
+                next = false;
+                neg += 1;
+                if (prev.my_vote === true) pos -= 1;
+            } else {
+                if (prev.my_vote === true) pos -= 1;
+                if (prev.my_vote === false) neg -= 1;
+                next = null;
+            }
+            return { ...prev, my_vote: next, positive_vote_count: pos, negative_vote_count: neg };
+        });
+    };
+
+    const handleVote = async (action: VoteAction) => {
+        if (!post) return;
+        const before = {
+            my_vote: post.my_vote,
+            pos: post.positive_vote_count,
+            neg: post.negative_vote_count,
+        };
+        applyVote(action);
+        try {
+            await votePost(post.id, action);
+        } catch (e) {
+            console.error('votePost failed', e);
+            setPost((prev) =>
+                prev
+                    ? {
+                          ...prev,
+                          my_vote: before.my_vote,
+                          positive_vote_count: before.pos,
+                          negative_vote_count: before.neg,
+                      }
+                    : prev,
+            );
+        }
+    };
+
+    const shareUrl =
+        typeof window !== 'undefined'
+            ? `${apiUrl}/post/${postId}`
+            : `/post/${postId}`;
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader
+                title=""
+                trailing={
+                    <MoreButton
+                        shareUrl={shareUrl}
+                        onReport={() => console.log('[Post] report stub')}
+                        onBlock={() => console.log('[Post] block stub')}
+                    />
+                }
+            />
+
+            {loading && (
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        padding: 40,
+                    }}
+                >
+                    <div className="ara-skeleton" style={{ width: '100%', height: 200 }} />
+                </div>
+            )}
+
+            {!loading && error && (
+                <div style={{ padding: 24, textAlign: 'center', color: 'var(--ara-text-tertiary)' }}>
+                    {error}
+                    <div style={{ marginTop: 12 }}>
+                        <button
+                            type="button"
+                            onClick={() => router.back()}
+                            style={{
+                                padding: '8px 16px',
+                                borderRadius: 999,
+                                border: '1px solid var(--ara-divider-strong)',
+                                background: 'transparent',
+                                cursor: 'pointer',
+                            }}
+                        >
+                            뒤로
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {!loading && !error && post && (
+                <>
+                    <ArticleHeader post={post} />
+
+                    <section
+                        style={{
+                            padding: '16px var(--ara-spacing-lg)',
+                            fontSize: 15,
+                            lineHeight: 1.6,
+                            color: 'var(--ara-text-primary)',
+                        }}
+                    >
+                        <TextEditor content={post.content} editable={false} />
+                    </section>
+
+                    {post.attachments && post.attachments.length > 0 && (
+                        <Attachments attachments={post.attachments} />
+                    )}
+
+                    <VoteRow
+                        myVote={post.my_vote}
+                        positive={post.positive_vote_count}
+                        negative={post.negative_vote_count}
+                        onVote={handleVote}
+                    />
+
+                    <section style={{ borderTop: '1px solid var(--ara-divider)' }}>
+                        <header
+                            style={{
+                                padding: '12px var(--ara-spacing-lg)',
+                                fontSize: 14,
+                                fontWeight: 600,
+                                color: 'var(--ara-text-primary)',
+                            }}
+                        >
+                            댓글 {post.comments?.length ?? 0}개
+                        </header>
+                        {post.comments && post.comments.length > 0 ? (
+                            post.comments.map((c) => (
+                                <CommentItem
+                                    key={c.id}
+                                    comment={c}
+                                    onReply={(id) => setReplyTarget(id)}
+                                    onChanged={load}
+                                />
+                            ))
+                        ) : (
+                            <div
+                                style={{
+                                    padding: 24,
+                                    textAlign: 'center',
+                                    color: 'var(--ara-text-tertiary)',
+                                    fontSize: 13,
+                                }}
+                            >
+                                첫 댓글을 남겨보세요.
+                            </div>
+                        )}
+                    </section>
+
+                    <ComposerSpacer height={80} />
+
+                    <CommentComposer
+                        postId={post.id}
+                        allowedNameTypes={post.name_type}
+                        replyToCommentId={replyTarget}
+                        onCancelReply={() => setReplyTarget(null)}
+                        onPosted={() => {
+                            setReplyTarget(null);
+                            load();
+                        }}
+                    />
+                </>
+            )}
+        </Screen>
+    );
+}

--- a/src/app/web_view/Search/page.tsx
+++ b/src/app/web_view/Search/page.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { fetchArticles } from '@/lib/api/board';
+import type { ResponsePost } from '@/lib/types/post';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { bridge } from '@/app/web_view/_bridge';
+import { formatDate } from '@/app/post/util/formatDate';
+
+function SearchInner() {
+    const router = useRouter();
+    const params = useSearchParams();
+    const initialQ = params?.get('q') ?? '';
+    const boardParam = params?.get('board');
+    const boardId = boardParam ? Number.parseInt(boardParam, 10) : undefined;
+
+    const [draft, setDraft] = useState(initialQ);
+    const [submittedQ, setSubmittedQ] = useState(initialQ);
+    const [loading, setLoading] = useState(false);
+    const [results, setResults] = useState<ResponsePost[]>([]);
+    const [error, setError] = useState<string | null>(null);
+
+    const runSearch = useCallback(
+        async (q: string) => {
+            const trimmed = q.trim();
+            if (!trimmed) {
+                setResults([]);
+                setError(null);
+                return;
+            }
+            setLoading(true);
+            setError(null);
+            try {
+                const data = await fetchArticles({
+                    query: trimmed,
+                    boardId: Number.isFinite(boardId) ? boardId : undefined,
+                    page: 1,
+                });
+                setResults((data?.results ?? []) as ResponsePost[]);
+            } catch (e) {
+                console.error('search failed', e);
+                setError('검색에 실패했습니다.');
+                setResults([]);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [boardId],
+    );
+
+    // Sync draft and run on URL change.
+    useEffect(() => {
+        setDraft(initialQ);
+        setSubmittedQ(initialQ);
+        if (initialQ) runSearch(initialQ);
+        else setResults([]);
+    }, [initialQ, runSearch]);
+
+    const submit = () => {
+        try {
+            bridge?.send('haptic', { kind: 'light' });
+        } catch {
+            /* noop */
+        }
+        const q = draft.trim();
+        setSubmittedQ(q);
+        // Push so back button returns to a previous query.
+        const next = new URLSearchParams();
+        if (q) next.set('q', q);
+        if (boardParam) next.set('board', boardParam);
+        const search = next.toString();
+        router.replace(`/web_view/Search${search ? `?${search}` : ''}`);
+        runSearch(q);
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader title="검색" />
+
+            <div
+                style={{
+                    position: 'sticky',
+                    top: 'var(--ara-header-height)',
+                    zIndex: 30,
+                    background: 'var(--ara-bg)',
+                    borderBottom: '1px solid var(--ara-divider)',
+                    padding: '8px var(--ara-spacing-lg)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                }}
+            >
+                <input
+                    type="search"
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            e.preventDefault();
+                            submit();
+                        }
+                    }}
+                    placeholder="검색어를 입력하세요"
+                    inputMode="search"
+                    enterKeyHint="search"
+                    autoCapitalize="none"
+                    style={{
+                        flex: 1,
+                        height: 36,
+                        padding: '0 12px',
+                        borderRadius: 18,
+                        border: '1px solid var(--ara-divider-strong)',
+                        background: 'var(--ara-bg-muted)',
+                        fontSize: 14,
+                        color: 'var(--ara-text-primary)',
+                        outline: 'none',
+                    }}
+                />
+                <button
+                    type="button"
+                    onClick={submit}
+                    aria-label="search"
+                    style={{
+                        flexShrink: 0,
+                        width: 36,
+                        height: 36,
+                        borderRadius: '50%',
+                        border: 0,
+                        background: 'var(--ara-primary)',
+                        color: '#fff',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        cursor: 'pointer',
+                    }}
+                >
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+                        <circle cx="11" cy="11" r="6" stroke="currentColor" strokeWidth="2" />
+                        <path d="M16 16L20 20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    </svg>
+                </button>
+            </div>
+
+            {loading && (
+                <div style={{ padding: 16 }}>
+                    <div className="ara-skeleton" style={{ width: '100%', height: 56, marginBottom: 8 }} />
+                    <div className="ara-skeleton" style={{ width: '100%', height: 56, marginBottom: 8 }} />
+                    <div className="ara-skeleton" style={{ width: '100%', height: 56 }} />
+                </div>
+            )}
+
+            {!loading && error && (
+                <div style={{ padding: 24, textAlign: 'center', color: 'var(--ara-text-tertiary)' }}>
+                    {error}
+                </div>
+            )}
+
+            {!loading && !error && submittedQ && results.length === 0 && (
+                <div
+                    style={{
+                        padding: 48,
+                        textAlign: 'center',
+                        color: 'var(--ara-text-tertiary)',
+                        fontSize: 14,
+                    }}
+                >
+                    검색 결과가 없습니다.
+                </div>
+            )}
+
+            {!loading && !error && results.length > 0 && (
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                    {results.map((post) => (
+                        <li
+                            key={post.id}
+                            className="ara-list-row"
+                            onClick={() => router.push(`/web_view/Post/${post.id}`)}
+                            style={{ flexDirection: 'column', alignItems: 'stretch', gap: 4 }}
+                        >
+                            <div
+                                style={{
+                                    fontSize: 12,
+                                    color: 'var(--ara-text-tertiary)',
+                                    display: 'flex',
+                                    gap: 6,
+                                    alignItems: 'center',
+                                }}
+                            >
+                                {post.parent_board?.ko_name && <span>{post.parent_board.ko_name}</span>}
+                                {post.parent_topic?.ko_name && (
+                                    <>
+                                        <span aria-hidden>·</span>
+                                        <span style={{ color: 'var(--ara-primary)' }}>
+                                            [{post.parent_topic.ko_name}]
+                                        </span>
+                                    </>
+                                )}
+                            </div>
+                            <div
+                                style={{
+                                    fontSize: 15,
+                                    fontWeight: 500,
+                                    color: 'var(--ara-text-primary)',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {post.title}
+                            </div>
+                            <div
+                                style={{
+                                    fontSize: 12,
+                                    color: 'var(--ara-text-tertiary)',
+                                    display: 'flex',
+                                    gap: 8,
+                                }}
+                            >
+                                <span>{post.created_by?.profile?.nickname ?? ''}</span>
+                                <span aria-hidden>·</span>
+                                <span>{post.created_at ? formatDate(post.created_at) : ''}</span>
+                                <span aria-hidden>·</span>
+                                <span>댓글 {post.comment_count ?? 0}</span>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </Screen>
+    );
+}
+
+export default function WebViewSearchPage() {
+    return (
+        <Suspense fallback={null}>
+            <SearchInner />
+        </Suspense>
+    );
+}

--- a/src/app/web_view/Terms/page.tsx
+++ b/src/app/web_view/Terms/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { fetchMe, updateTos } from '@/lib/api/user';
+import { tosContent } from '@/app/tos/content';
+
+export default function TermsPage() {
+    const router = useRouter();
+    const search = useSearchParams();
+    const requireAccept = search?.get('accept') === 'true';
+    const [meId, setMeId] = useState<number | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (!requireAccept) return;
+        fetchMe()
+            .then((data) => setMeId(data?.id ?? null))
+            .catch((e) => console.warn('fetchMe failed', e));
+    }, [requireAccept]);
+
+    const onAccept = async () => {
+        if (submitting) return;
+        setSubmitting(true);
+        try {
+            if (meId != null) {
+                await updateTos(meId);
+            }
+            router.replace('/web_view/Main');
+        } catch (e) {
+            console.warn('updateTos failed', e);
+            alert('동의 처리에 실패했어요. 잠시 후 다시 시도해 주세요.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const ko = tosContent.ko;
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader title="이용약관" />
+
+            <div
+                style={{
+                    padding: 'var(--ara-spacing-lg)',
+                    paddingBottom: requireAccept ? 96 : 'var(--ara-spacing-xl)',
+                }}
+            >
+                <p style={{ fontSize: 13, color: 'var(--ara-text-secondary)', marginTop: 0 }}>
+                    {ko.lastUpdated}
+                </p>
+
+                {ko.tos.map((s, i) => (
+                    <section key={i} style={{ marginBottom: 'var(--ara-spacing-xl)' }}>
+                        <h2
+                            style={{
+                                fontSize: 15,
+                                fontWeight: 700,
+                                color: 'var(--ara-text-primary)',
+                                margin: '0 0 8px',
+                            }}
+                        >
+                            {s.title}
+                        </h2>
+                        <p
+                            style={{
+                                fontSize: 13,
+                                lineHeight: 1.7,
+                                color: 'var(--ara-text-secondary)',
+                                margin: 0,
+                                whiteSpace: 'pre-wrap',
+                            }}
+                        >
+                            {s.content}
+                        </p>
+                    </section>
+                ))}
+            </div>
+
+            {requireAccept && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        left: 0,
+                        right: 0,
+                        bottom: 'var(--ara-safe-bottom)',
+                        padding: 'var(--ara-spacing-lg)',
+                        background: 'var(--ara-bg)',
+                        borderTop: '1px solid var(--ara-divider)',
+                    }}
+                >
+                    <button
+                        type="button"
+                        onClick={onAccept}
+                        disabled={submitting}
+                        style={{
+                            width: '100%',
+                            padding: '14px',
+                            borderRadius: 'var(--ara-radius-md)',
+                            border: 0,
+                            background: 'var(--ara-primary)',
+                            color: 'var(--ara-text-on-primary)',
+                            fontSize: 15,
+                            fontWeight: 700,
+                            cursor: submitting ? 'default' : 'pointer',
+                        }}
+                    >
+                        {submitting ? '처리 중...' : '동의'}
+                    </button>
+                </div>
+            )}
+        </Screen>
+    );
+}

--- a/src/app/web_view/User/[id]/page.tsx
+++ b/src/app/web_view/User/[id]/page.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Screen, AppHeader } from '@/app/web_view/_components';
+import { blockUser } from '@/lib/api/user';
+import { fetchUserProfile, fetchUserPosts } from '@/lib/api/user_profile';
+
+interface UserProfile {
+    id: number;
+    user?: number;
+    nickname?: string;
+    picture?: string | null;
+    email?: string;
+    sso_user_info?: { email?: string } | null;
+}
+
+interface PostRow {
+    id: number;
+    title: string;
+    parent_board?: { ko_name?: string } | null;
+}
+
+export default function UserViewPage() {
+    const router = useRouter();
+    const params = useParams();
+    const idParam = params?.id;
+    const userId =
+        typeof idParam === 'string'
+            ? Number(idParam)
+            : Array.isArray(idParam)
+                ? Number(idParam[0])
+                : NaN;
+
+    const [user, setUser] = useState<UserProfile | null>(null);
+    const [posts, setPosts] = useState<PostRow[]>([]);
+    const [page, setPage] = useState(1);
+    const [hasNext, setHasNext] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        if (!userId || isNaN(userId)) return;
+        fetchUserProfile(userId)
+            .then((data) => setUser(data))
+            .catch((e) => console.warn('fetchUserProfile failed', e));
+    }, [userId]);
+
+    const loadPosts = useCallback(
+        async (p: number) => {
+            if (!userId || isNaN(userId)) return;
+            setLoading(true);
+            try {
+                const data = await fetchUserPosts(userId, p);
+                const results = (data?.results ?? []) as PostRow[];
+                setPosts((prev) => (p === 1 ? results : [...prev, ...results]));
+                setHasNext(Boolean(data?.next));
+                setPage(p);
+            } catch (e) {
+                console.warn('fetchUserPosts failed', e);
+            } finally {
+                setLoading(false);
+            }
+        },
+        [userId],
+    );
+
+    useEffect(() => {
+        if (!userId || isNaN(userId)) return;
+        loadPosts(1);
+    }, [userId, loadPosts]);
+
+    const onBlock = async () => {
+        if (!userId || busy) return;
+        setMenuOpen(false);
+        if (!confirm('이 사용자를 차단하시겠어요?')) return;
+        setBusy(true);
+        try {
+            await blockUser(userId);
+            alert('차단했어요.');
+            router.back();
+        } catch (e) {
+            console.warn('blockUser failed', e);
+            alert('차단에 실패했어요.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const onMessage = () => {
+        setMenuOpen(false);
+        // TODO: native 쪽지 기능 연결
+        alert('쪽지 기능은 준비 중이에요.');
+    };
+
+    return (
+        <Screen withTabBar={false}>
+            <AppHeader
+                title={user?.nickname ?? '프로필'}
+                trailing={
+                    <div style={{ position: 'relative' }}>
+                        <button
+                            type="button"
+                            className="ara-header__btn"
+                            onClick={() => setMenuOpen((v) => !v)}
+                            aria-label="more"
+                        >
+                            <span style={{ fontSize: 22, fontWeight: 700 }}>⋯</span>
+                        </button>
+                        {menuOpen && (
+                            <div
+                                style={{
+                                    position: 'absolute',
+                                    right: 0,
+                                    top: 36,
+                                    background: 'var(--ara-bg)',
+                                    border: '1px solid var(--ara-divider-strong)',
+                                    borderRadius: 'var(--ara-radius-md)',
+                                    boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
+                                    minWidth: 120,
+                                    overflow: 'hidden',
+                                    zIndex: 60,
+                                }}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={onBlock}
+                                    style={menuItemStyle}
+                                >
+                                    차단
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={onMessage}
+                                    style={{ ...menuItemStyle, borderTop: '1px solid var(--ara-divider)' }}
+                                >
+                                    쪽지
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                }
+            />
+
+            <section
+                className="ara-card"
+                style={{
+                    margin: 'var(--ara-spacing-lg)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 'var(--ara-spacing-lg)',
+                }}
+            >
+                <div
+                    style={{
+                        width: 56,
+                        height: 56,
+                        borderRadius: 999,
+                        background: 'var(--ara-bg-muted)',
+                        backgroundImage: user?.picture ? `url(${user.picture})` : undefined,
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                        flexShrink: 0,
+                    }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 16, fontWeight: 700 }}>{user?.nickname ?? '...'}</div>
+                </div>
+            </section>
+
+            <h2
+                style={{
+                    margin: '0 var(--ara-spacing-lg) var(--ara-spacing-sm)',
+                    fontSize: 14,
+                    fontWeight: 600,
+                    color: 'var(--ara-text-secondary)',
+                }}
+            >
+                작성한 글
+            </h2>
+
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                {posts.map((p) => (
+                    <li
+                        key={p.id}
+                        className="ara-list-row"
+                        onClick={() => router.push(`/web_view/Post/${p.id}`)}
+                    >
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <div
+                                style={{
+                                    fontSize: 14,
+                                    fontWeight: 500,
+                                    whiteSpace: 'nowrap',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                }}
+                            >
+                                {p.title}
+                            </div>
+                            {p.parent_board?.ko_name && (
+                                <div
+                                    style={{
+                                        fontSize: 11,
+                                        color: 'var(--ara-text-tertiary)',
+                                        marginTop: 2,
+                                    }}
+                                >
+                                    {p.parent_board.ko_name}
+                                </div>
+                            )}
+                        </div>
+                    </li>
+                ))}
+            </ul>
+
+            {!loading && posts.length === 0 && (
+                <div
+                    style={{
+                        padding: '40px 16px',
+                        textAlign: 'center',
+                        color: 'var(--ara-text-secondary)',
+                        fontSize: 13,
+                    }}
+                >
+                    작성한 글이 없어요.
+                </div>
+            )}
+
+            {hasNext && (
+                <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--ara-spacing-md)' }}>
+                    <button
+                        type="button"
+                        onClick={() => loadPosts(page + 1)}
+                        disabled={loading}
+                        style={{
+                            padding: '8px 18px',
+                            borderRadius: 'var(--ara-radius-md)',
+                            border: '1px solid var(--ara-divider-strong)',
+                            background: 'var(--ara-bg)',
+                            color: 'var(--ara-text-primary)',
+                            fontSize: 13,
+                            cursor: loading ? 'default' : 'pointer',
+                        }}
+                    >
+                        {loading ? '불러오는 중...' : '더 보기'}
+                    </button>
+                </div>
+            )}
+        </Screen>
+    );
+}
+
+const menuItemStyle: React.CSSProperties = {
+    display: 'block',
+    width: '100%',
+    padding: '10px 14px',
+    background: 'transparent',
+    border: 0,
+    textAlign: 'left',
+    fontSize: 13,
+    color: 'var(--ara-text-primary)',
+    cursor: 'pointer',
+};

--- a/src/app/web_view/_bridge/PROTOCOL.md
+++ b/src/app/web_view/_bridge/PROTOCOL.md
@@ -1,0 +1,139 @@
+# Ara WebView ↔ Native Bridge Protocol
+
+This document defines the message contract between the Next.js web app
+(running inside a single `WebView`) and the native Flutter shell that hosts it.
+
+The single source of truth for **types** is `./types.ts` (web side) and
+`new-ara-app/lib/bridge/bridge_types.dart` (native side). Keep them in sync
+when adding/removing messages.
+
+> Channel name: `FlutterChannel`
+> Direction: bidirectional
+> Transport: stringified JSON (with backwards-compat for legacy plain strings)
+
+---
+
+## 1. Wire format
+
+### Web → Native
+The web calls
+```ts
+window.FlutterChannel.postMessage(JSON.stringify(envelope))
+```
+
+`envelope` shape:
+```ts
+{
+  v: 1,                  // protocol version
+  id?: string,           // optional, used to correlate responses
+  type: string,          // command name, see §3
+  payload?: unknown      // command-specific data
+}
+```
+
+**Legacy compatibility:** If a postMessage value is *not* a JSON object with
+`v`, the native side falls back to the legacy string protocol used by
+`PostWrite` and `Meal` pages (e.g. `'PostWritePageExit'`, `'meal_page_exit'`).
+New code MUST use the JSON envelope.
+
+### Native → Web
+The native side dispatches a `CustomEvent` on `window`:
+```js
+window.dispatchEvent(new CustomEvent('flutter:message', { detail: envelope }))
+```
+
+`envelope` shape (responses or events):
+```ts
+{
+  v: 1,
+  id?: string,           // mirrors the request id, for response correlation
+  type: string,          // event name or '<requestType>:result'
+  payload?: unknown,
+  error?: { code: string, message: string }
+}
+```
+
+The web client also exposes a global `window.AraBridge` (see `client.ts`)
+which wraps both directions with a `request<T>(type, payload)` Promise API.
+
+---
+
+## 2. Lifecycle
+
+1. Native creates the WebView, injects the `FlutterChannel` JS handler, loads
+   `https://newara.dev.sparcs.org/web_view/Main`.
+2. On DOMContentLoaded, web sends `{ type: 'ready', payload: { route } }`.
+3. Native responds with `{ type: 'bridge:ready', payload: { platform, osVersion, appVersion, locale, safeArea } }`.
+4. Web stores capabilities; from this point on, `window.AraBridge.isNative === true`.
+5. If not in a WebView, `bridge:ready` never arrives within 500ms; web falls
+   back to "browser mode" and bridge methods become no-ops (or throw).
+
+---
+
+## 3. Web → Native commands
+
+All commands are best-effort — native may respond with an error envelope.
+
+| `type`                    | `payload`                                 | `result`                              | Notes |
+|---------------------------|-------------------------------------------|----------------------------------------|-------|
+| `ready`                   | `{ route: string }`                       | —                                      | Sent once on first paint. |
+| `log`                     | `{ level, message, data? }`               | —                                      | Forward to native console. |
+| `goBack`                  | —                                         | —                                      | Pop a native screen if any; otherwise `history.back()`. |
+| `exit`                    | —                                         | —                                      | Replaces legacy `'PostWritePageExit'` / `'meal_page_exit'` strings. |
+| `setStatusBar`            | `{ color: '#RRGGBB', style: 'light'\|'dark' }` | —                                  | Tint status bar. |
+| `setSafeArea`             | `{ top, bottom, left, right }`            | —                                      | Reserved for future. |
+| `openExternal`            | `{ url: string }`                         | —                                      | Open in external browser. |
+| `share`                   | `{ title?, text?, url? }`                 | `{ shared: boolean }`                  | OS share sheet. |
+| `pickImage`               | `{ source: 'gallery'\|'camera', maxBytes? }` | `{ uri: string, mime: string, name: string, base64?: string }` | Returns a temporary uri the web can upload directly via fetch. |
+| `pickFile`                | `{ accept?: string[], multiple?: boolean }` | `{ files: { uri, mime, name, size }[] }` | |
+| `requestPermission`       | `{ kind: 'camera'\|'photos'\|'notifications'\|'microphone' }` | `{ granted: boolean, status: 'granted'\|'denied'\|'permanentlyDenied' }` | |
+| `getPushToken`            | —                                         | `{ token: string\|null, platform: 'fcm'\|'apns' }` | |
+| `subscribeTopic`          | `{ topic: string }`                       | —                                      | |
+| `unsubscribeTopic`        | `{ topic: string }`                       | —                                      | |
+| `setBadgeCount`           | `{ count: number }`                       | —                                      | iOS badge / Android indicator. |
+| `haptic`                  | `{ kind: 'light'\|'medium'\|'heavy'\|'selection' }` | —                            | |
+| `clipboardWrite`          | `{ text: string }`                        | —                                      | |
+| `clipboardRead`           | —                                         | `{ text: string }`                     | |
+| `setSession`              | `{ cookie: string }`                      | —                                      | Web hands updated session cookie to native (rare). |
+| `clearSession`            | —                                         | —                                      | After logout. |
+| `reportHeight`            | `{ height: number }`                      | —                                      | Legacy `HeightChannel` use case. |
+
+---
+
+## 4. Native → Web events
+
+| `type`                | `payload`                                                  | When |
+|-----------------------|------------------------------------------------------------|------|
+| `bridge:ready`        | `{ platform, osVersion, appVersion, locale, safeArea }`    | After web sends `ready`. |
+| `back:pressed`        | —                                                          | Android hardware back button. Web returns `{ handled: boolean }` via the response channel; if `false`, native pops/exits. |
+| `appstate:changed`    | `{ state: 'foreground'\|'background'\|'inactive' }`        | App lifecycle changes. |
+| `network:changed`     | `{ online: boolean, type?: 'wifi'\|'cellular' }`           | Connectivity changes. |
+| `keyboard:changed`    | `{ height: number, visible: boolean }`                     | iOS only — Android relies on visualViewport. |
+| `push:received`       | `{ title?, body?, data?, foreground: boolean }`            | A push arrived (foreground or background-tap). |
+| `push:opened`         | `{ data, deepLink?: string }`                              | User tapped a push. |
+| `deeplink:received`   | `{ url: string }`                                          | App opened via custom scheme or universal link. |
+| `auth:expired`        | —                                                          | Native detected a 401 (rare, web normally does this). |
+| `<requestType>:result`| see §3                                                     | Response to a Web→Native request. |
+| `<requestType>:error` | `{ error: { code, message } }`                             | Error response. |
+
+---
+
+## 5. Errors
+
+```ts
+type BridgeError =
+  | 'unsupported'        // unknown command for this app version
+  | 'denied'             // permission denied
+  | 'cancelled'          // user cancelled
+  | 'invalid_payload'    // bad input
+  | 'unavailable'        // feature not available on this platform
+  | 'internal'           // unexpected
+```
+
+---
+
+## 6. Versioning
+
+- Increment `v` only on a breaking change.
+- Add new `type`s freely; web should feature-detect via `bridge:ready.payload.appVersion`
+  or by sending the request and handling `unsupported`.

--- a/src/app/web_view/_bridge/client.ts
+++ b/src/app/web_view/_bridge/client.ts
@@ -1,0 +1,195 @@
+/**
+ * Bridge client. Lives on `window.AraBridge` after `installBridge()`.
+ *
+ * Usage:
+ *   import { bridge } from '@/app/web_view/_bridge/client'
+ *   bridge.send('exit')
+ *   const { uri } = await bridge.request('pickImage', { source: 'gallery' })
+ *   const off = bridge.on('back:pressed', () => router.back())
+ *
+ * In a browser (no Flutter host) every command is a no-op resolving with
+ * `undefined` and `bridge.isNative` is `false`.
+ */
+
+import {
+    CommandReq,
+    CommandRes,
+    CommandType,
+    EventPayload,
+    EventType,
+    IncomingEnvelope,
+    PROTOCOL_VERSION,
+    RequestEnvelope,
+} from './types';
+
+type Listener<T extends EventType> = (payload: EventPayload<T>) => void;
+
+interface FlutterChannelLike {
+    postMessage: (msg: string) => void;
+}
+
+declare global {
+    interface Window {
+        FlutterChannel?: FlutterChannelLike;
+        AraBridge?: AraBridge;
+    }
+}
+
+const READY_TIMEOUT_MS = 800;
+
+class AraBridge {
+    private pending = new Map<
+        string,
+        { resolve: (v: unknown) => void; reject: (e: Error) => void; timeout: ReturnType<typeof setTimeout> }
+    >();
+    private listeners = new Map<EventType, Set<Listener<EventType>>>();
+    private nextId = 0;
+    private _isNative = false;
+    private _capabilities: EventPayload<'bridge:ready'> | null = null;
+    private _readyPromise: Promise<EventPayload<'bridge:ready'> | null>;
+
+    constructor() {
+        if (typeof window === 'undefined') {
+            this._readyPromise = Promise.resolve(null);
+            return;
+        }
+
+        window.addEventListener('flutter:message', this.handleIncoming as EventListener);
+
+        this._readyPromise = new Promise((resolve) => {
+            const off = this.on('bridge:ready', (cap) => {
+                this._isNative = true;
+                this._capabilities = cap;
+                off();
+                resolve(cap);
+            });
+            setTimeout(() => {
+                if (!this._isNative) resolve(null);
+            }, READY_TIMEOUT_MS);
+        });
+    }
+
+    get isNative(): boolean {
+        return this._isNative;
+    }
+
+    get capabilities(): EventPayload<'bridge:ready'> | null {
+        return this._capabilities;
+    }
+
+    /** Resolves with capabilities once native says hello, or `null` after a timeout (browser mode). */
+    ready(): Promise<EventPayload<'bridge:ready'> | null> {
+        return this._readyPromise;
+    }
+
+    /** Fire-and-forget command. */
+    send<T extends CommandType>(type: T, payload?: CommandReq<T>): void {
+        this.post({ v: PROTOCOL_VERSION, type, payload } as RequestEnvelope<T>);
+    }
+
+    /** Request/response. Rejects with BridgeError on `:error` responses or timeout. */
+    request<T extends CommandType>(type: T, payload?: CommandReq<T>, timeoutMs = 15000): Promise<CommandRes<T>> {
+        if (!this.canPost()) {
+            return Promise.reject(new Error(`bridge.${type}: not running inside native shell`));
+        }
+        const id = `req-${++this.nextId}`;
+        return new Promise<CommandRes<T>>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                this.pending.delete(id);
+                reject(new Error(`bridge.${type}: timed out after ${timeoutMs}ms`));
+            }, timeoutMs);
+            this.pending.set(id, {
+                resolve: resolve as (v: unknown) => void,
+                reject,
+                timeout,
+            });
+            this.post({ v: PROTOCOL_VERSION, id, type, payload } as RequestEnvelope<T>);
+        });
+    }
+
+    /** Subscribe to a native event. Returns an `off()` function. */
+    on<T extends EventType>(type: T, listener: Listener<T>): () => void {
+        let set = this.listeners.get(type) as Set<Listener<T>> | undefined;
+        if (!set) {
+            set = new Set();
+            this.listeners.set(type, set as unknown as Set<Listener<EventType>>);
+        }
+        set.add(listener);
+        return () => set!.delete(listener);
+    }
+
+    private canPost(): boolean {
+        return typeof window !== 'undefined' && typeof window.FlutterChannel?.postMessage === 'function';
+    }
+
+    private post(env: RequestEnvelope): void {
+        if (!this.canPost()) return;
+        try {
+            window.FlutterChannel!.postMessage(JSON.stringify(env));
+        } catch (e) {
+            console.warn('[AraBridge] postMessage failed', e);
+        }
+    }
+
+    private handleIncoming = (e: Event): void => {
+        const ev = e as CustomEvent<IncomingEnvelope>;
+        const env = ev.detail;
+        if (!env || env.v !== PROTOCOL_VERSION) return;
+
+        // Response correlation
+        if (env.type.endsWith(':result') || env.type.endsWith(':error')) {
+            if (!('id' in env) || !env.id) return;
+            const slot = this.pending.get(env.id);
+            if (!slot) return;
+            this.pending.delete(env.id);
+            clearTimeout(slot.timeout);
+            if (env.type.endsWith(':error')) {
+                const err = (env as { error?: { code: string; message: string } }).error;
+                slot.reject(new Error(`[${err?.code ?? 'unknown'}] ${err?.message ?? 'bridge error'}`));
+            } else {
+                slot.resolve((env as { payload?: unknown }).payload);
+            }
+            return;
+        }
+
+        // Event dispatch
+        const set = this.listeners.get(env.type as EventType);
+        if (set) {
+            for (const l of set) {
+                try {
+                    l((env as { payload?: unknown }).payload as EventPayload<EventType>);
+                } catch (err) {
+                    console.warn('[AraBridge] listener threw', err);
+                }
+            }
+        }
+    };
+}
+
+let _instance: AraBridge | null = null;
+
+export function getBridge(): AraBridge {
+    if (typeof window === 'undefined') {
+        return new AraBridge();
+    }
+    if (!_instance) {
+        _instance = new AraBridge();
+        window.AraBridge = _instance;
+        // After hydration, signal native that we're up.
+        if (typeof document !== 'undefined') {
+            const sendReady = () => {
+                _instance!.send('ready', { route: window.location.pathname });
+            };
+            if (document.readyState === 'complete' || document.readyState === 'interactive') {
+                queueMicrotask(sendReady);
+            } else {
+                document.addEventListener('DOMContentLoaded', sendReady, { once: true });
+            }
+        }
+    }
+    return _instance;
+}
+
+export const bridge = typeof window !== 'undefined' ? getBridge() : (null as unknown as AraBridge);
+
+export type { AraBridge };

--- a/src/app/web_view/_bridge/index.ts
+++ b/src/app/web_view/_bridge/index.ts
@@ -1,0 +1,4 @@
+export { bridge, getBridge } from './client';
+export type { AraBridge } from './client';
+export { useBridgeEvent, useIsNative } from './useBridge';
+export * from './types';

--- a/src/app/web_view/_bridge/types.ts
+++ b/src/app/web_view/_bridge/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Single source of truth for bridge message types.
+ *
+ * Keep in sync with `new-ara-app/lib/bridge/bridge_types.dart`.
+ * See `./PROTOCOL.md` for the human-readable spec.
+ */
+
+export const PROTOCOL_VERSION = 1 as const;
+
+export type Platform = 'ios' | 'android';
+export type PushPlatform = 'fcm' | 'apns';
+export type PermissionKind = 'camera' | 'photos' | 'notifications' | 'microphone';
+export type PermissionStatus = 'granted' | 'denied' | 'permanentlyDenied';
+export type StatusBarStyle = 'light' | 'dark';
+export type HapticKind = 'light' | 'medium' | 'heavy' | 'selection';
+export type AppLifecycleState = 'foreground' | 'background' | 'inactive';
+export type NetworkType = 'wifi' | 'cellular';
+
+export interface SafeAreaInsets {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+}
+
+export interface BridgeError {
+    code:
+        | 'unsupported'
+        | 'denied'
+        | 'cancelled'
+        | 'invalid_payload'
+        | 'unavailable'
+        | 'internal';
+    message: string;
+}
+
+/** Web → Native */
+export type CommandMap = {
+    ready: { req: { route: string }; res: void };
+    log: { req: { level: 'debug' | 'info' | 'warn' | 'error'; message: string; data?: unknown }; res: void };
+    goBack: { req: void; res: void };
+    exit: { req: void; res: void };
+    setStatusBar: { req: { color: string; style: StatusBarStyle }; res: void };
+    setSafeArea: { req: SafeAreaInsets; res: void };
+    openExternal: { req: { url: string }; res: void };
+    share: { req: { title?: string; text?: string; url?: string }; res: { shared: boolean } };
+    pickImage: {
+        req: { source: 'gallery' | 'camera'; maxBytes?: number };
+        res: { uri: string; mime: string; name: string; base64?: string };
+    };
+    pickFile: {
+        req: { accept?: string[]; multiple?: boolean };
+        res: { files: Array<{ uri: string; mime: string; name: string; size: number }> };
+    };
+    requestPermission: {
+        req: { kind: PermissionKind };
+        res: { granted: boolean; status: PermissionStatus };
+    };
+    getPushToken: { req: void; res: { token: string | null; platform: PushPlatform } };
+    subscribeTopic: { req: { topic: string }; res: void };
+    unsubscribeTopic: { req: { topic: string }; res: void };
+    setBadgeCount: { req: { count: number }; res: void };
+    haptic: { req: { kind: HapticKind }; res: void };
+    clipboardWrite: { req: { text: string }; res: void };
+    clipboardRead: { req: void; res: { text: string } };
+    setSession: { req: { cookie: string }; res: void };
+    clearSession: { req: void; res: void };
+    reportHeight: { req: { height: number }; res: void };
+};
+
+export type CommandType = keyof CommandMap;
+export type CommandReq<T extends CommandType> = CommandMap[T]['req'];
+export type CommandRes<T extends CommandType> = CommandMap[T]['res'];
+
+/** Native → Web events (not direct responses) */
+export type EventMap = {
+    'bridge:ready': {
+        platform: Platform;
+        osVersion: string;
+        appVersion: string;
+        locale: string;
+        safeArea: SafeAreaInsets;
+    };
+    'back:pressed': void;
+    'appstate:changed': { state: AppLifecycleState };
+    'network:changed': { online: boolean; type?: NetworkType };
+    'keyboard:changed': { height: number; visible: boolean };
+    'push:received': { title?: string; body?: string; data?: Record<string, unknown>; foreground: boolean };
+    'push:opened': { data: Record<string, unknown>; deepLink?: string };
+    'deeplink:received': { url: string };
+    'auth:expired': void;
+};
+
+export type EventType = keyof EventMap;
+export type EventPayload<T extends EventType> = EventMap[T];
+
+/** Wire envelope. */
+export interface RequestEnvelope<T extends CommandType = CommandType> {
+    v: typeof PROTOCOL_VERSION;
+    id?: string;
+    type: T;
+    payload?: CommandReq<T>;
+}
+
+export interface ResponseEnvelope<T extends CommandType = CommandType> {
+    v: typeof PROTOCOL_VERSION;
+    id?: string;
+    type: `${T}:result` | `${T}:error`;
+    payload?: CommandRes<T>;
+    error?: BridgeError;
+}
+
+export interface EventEnvelope<T extends EventType = EventType> {
+    v: typeof PROTOCOL_VERSION;
+    type: T;
+    payload?: EventPayload<T>;
+}
+
+export type IncomingEnvelope = ResponseEnvelope | EventEnvelope;

--- a/src/app/web_view/_bridge/useBridge.ts
+++ b/src/app/web_view/_bridge/useBridge.ts
@@ -1,0 +1,37 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { getBridge } from './client';
+import type { EventPayload, EventType } from './types';
+
+/**
+ * Subscribe to a native event for the lifetime of a component.
+ *
+ *   useBridgeEvent('back:pressed', () => router.back())
+ */
+export function useBridgeEvent<T extends EventType>(type: T, handler: (payload: EventPayload<T>) => void): void {
+    const ref = useRef(handler);
+    ref.current = handler;
+    useEffect(() => {
+        const bridge = getBridge();
+        return bridge.on(type, (p) => ref.current(p));
+    }, [type]);
+}
+
+/** Returns true once the native bridge has greeted us; null while pending. */
+export function useIsNative(): boolean | null {
+    const [isNative, setIsNative] = useState<boolean | null>(null);
+    useEffect(() => {
+        let cancelled = false;
+        getBridge()
+            .ready()
+            .then((cap) => {
+                if (!cancelled) setIsNative(!!cap);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+    return isNative;
+}

--- a/src/app/web_view/_components/AppHeader.tsx
+++ b/src/app/web_view/_components/AppHeader.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+interface AppHeaderProps {
+    title?: string;
+    leading?: ReactNode;
+    trailing?: ReactNode;
+    onBack?: () => void;
+    showBack?: boolean;
+}
+
+export function AppHeader({ title, leading, trailing, onBack, showBack = true }: AppHeaderProps) {
+    const router = useRouter();
+
+    const handleBack = () => {
+        if (onBack) return onBack();
+        if (typeof window !== 'undefined' && window.history.length > 1) {
+            router.back();
+        }
+    };
+
+    return (
+        <header className="ara-header">
+            <div style={{ width: 36 }}>
+                {leading ?? (showBack ? (
+                    <button type="button" className="ara-header__btn" onClick={handleBack} aria-label="back">
+                        <BackIcon />
+                    </button>
+                ) : null)}
+            </div>
+            <h1 className="ara-header__title">{title ?? ''}</h1>
+            <div style={{ width: 36, display: 'flex', justifyContent: 'flex-end' }}>{trailing ?? null}</div>
+        </header>
+    );
+}
+
+function BackIcon() {
+    return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+            <path
+                d="M12.5 4L6.5 10L12.5 16"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}

--- a/src/app/web_view/_components/BottomTabBar.tsx
+++ b/src/app/web_view/_components/BottomTabBar.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+interface Tab {
+    path: string;
+    matcher: RegExp;
+    label: string;
+    icon: ReactNode;
+}
+
+const TABS: Tab[] = [
+    {
+        path: '/web_view/Main',
+        matcher: /^\/web_view\/Main\/?$/,
+        label: '홈',
+        icon: <HomeIcon />,
+    },
+    {
+        path: '/web_view/Board',
+        matcher: /^\/web_view\/Board(\/|$)/,
+        label: '게시판',
+        icon: <BoardIcon />,
+    },
+    {
+        path: '/web_view/Notifications',
+        matcher: /^\/web_view\/Notifications(\/|$)/,
+        label: '알림',
+        icon: <BellIcon />,
+    },
+    {
+        path: '/web_view/MyInfo',
+        matcher: /^\/web_view\/MyInfo(\/|$)/,
+        label: '내 정보',
+        icon: <PersonIcon />,
+    },
+];
+
+export function BottomTabBar() {
+    const pathname = usePathname();
+    const router = useRouter();
+
+    return (
+        <nav className="ara-tabbar" role="tablist" aria-label="primary">
+            {TABS.map((t) => {
+                const active = t.matcher.test(pathname ?? '');
+                return (
+                    <button
+                        key={t.path}
+                        type="button"
+                        role="tab"
+                        aria-selected={active}
+                        data-active={active}
+                        className="ara-tabbar__btn"
+                        onClick={() => router.push(t.path)}
+                    >
+                        <span className="ara-tabbar__icon">{t.icon}</span>
+                        <span>{t.label}</span>
+                    </button>
+                );
+            })}
+        </nav>
+    );
+}
+
+export function isTabRoot(pathname: string | null): boolean {
+    if (!pathname) return false;
+    return TABS.some((t) => t.matcher.test(pathname));
+}
+
+function HomeIcon() {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path
+                d="M4 11L12 4L20 11V19C20 19.5523 19.5523 20 19 20H15V14H9V20H5C4.44772 20 4 19.5523 4 19V11Z"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
+
+function BoardIcon() {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <rect x="4" y="5" width="16" height="14" rx="2" stroke="currentColor" strokeWidth="1.6" />
+            <path d="M8 9H16M8 13H16M8 17H13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+function BellIcon() {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <path
+                d="M6 16V11C6 7.68629 8.68629 5 12 5C15.3137 5 18 7.68629 18 11V16L20 18H4L6 16Z"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinejoin="round"
+            />
+            <path d="M10 21H14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+function PersonIcon() {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+            <circle cx="12" cy="9" r="3.5" stroke="currentColor" strokeWidth="1.6" />
+            <path d="M5 19C5 15.6863 8.13401 13 12 13C15.866 13 19 15.6863 19 19" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+        </svg>
+    );
+}

--- a/src/app/web_view/_components/Screen.tsx
+++ b/src/app/web_view/_components/Screen.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { isTabRoot } from './BottomTabBar';
+
+interface ScreenProps {
+    children: ReactNode;
+    /** When true, leave space for the bottom tab bar. Defaults to "auto":
+     *  on a tab root path we reserve space; on detail pages we don't. */
+    withTabBar?: boolean | 'auto';
+    className?: string;
+}
+
+/**
+ * Standard mobile screen wrapper. Applies safe-area padding and reserves
+ * space for the bottom tab bar when appropriate. Use this as the root of
+ * any `web_view/<route>/page.tsx`.
+ */
+export function Screen({ children, withTabBar = 'auto', className }: ScreenProps) {
+    const pathname = usePathname();
+    const showTabBar = withTabBar === 'auto' ? isTabRoot(pathname) : withTabBar;
+
+    return (
+        <main
+            className={[
+                'ara-screen',
+                showTabBar ? 'ara-screen--with-tabbar' : 'ara-screen--no-tabbar',
+                className ?? '',
+            ]
+                .filter(Boolean)
+                .join(' ')}
+        >
+            {children}
+        </main>
+    );
+}

--- a/src/app/web_view/_components/StickyComposer.tsx
+++ b/src/app/web_view/_components/StickyComposer.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+
+interface StickyComposerProps {
+    children: ReactNode;
+    /** Reserve space for the bottom tab bar in addition to safe area. */
+    aboveTabBar?: boolean;
+    className?: string;
+    style?: CSSProperties;
+}
+
+/**
+ * A bar that sticks to the bottom of the viewport and lifts itself above the
+ * software keyboard. Use it for comment input, message composers, etc.
+ *
+ * The lift is driven by the `--ara-keyboard-height` CSS variable, which the
+ * web_view layout updates from `useKeyboard()` (visualViewport) and from the
+ * native `keyboard:changed` bridge event.
+ */
+export function StickyComposer({ children, aboveTabBar = false, className, style }: StickyComposerProps) {
+    return (
+        <div
+            className={['ara-composer', className ?? ''].filter(Boolean).join(' ')}
+            style={{
+                position: 'fixed',
+                left: 0,
+                right: 0,
+                bottom: aboveTabBar
+                    ? 'calc(var(--ara-keyboard-height, 0px) + var(--ara-tab-height) + var(--ara-safe-bottom))'
+                    : 'calc(var(--ara-keyboard-height, 0px) + var(--ara-safe-bottom))',
+                background: 'var(--ara-bg)',
+                borderTop: '1px solid var(--ara-divider)',
+                paddingLeft: 'var(--ara-safe-left)',
+                paddingRight: 'var(--ara-safe-right)',
+                transition: 'bottom 0.16s ease',
+                zIndex: 45,
+                ...style,
+            }}
+        >
+            {children}
+        </div>
+    );
+}
+
+/**
+ * Spacer to place at the end of a scrollable region so its last item isn't
+ * hidden by the StickyComposer.
+ */
+export function ComposerSpacer({ height = 64, aboveTabBar = false }: { height?: number; aboveTabBar?: boolean }) {
+    return (
+        <div
+            aria-hidden
+            style={{
+                height: aboveTabBar
+                    ? `calc(${height}px + var(--ara-tab-height) + var(--ara-safe-bottom))`
+                    : `calc(${height}px + var(--ara-safe-bottom))`,
+            }}
+        />
+    );
+}

--- a/src/app/web_view/_components/index.ts
+++ b/src/app/web_view/_components/index.ts
@@ -1,0 +1,4 @@
+export { AppHeader } from './AppHeader';
+export { BottomTabBar, isTabRoot } from './BottomTabBar';
+export { Screen } from './Screen';
+export { StickyComposer, ComposerSpacer } from './StickyComposer';

--- a/src/app/web_view/_styles/tokens.css
+++ b/src/app/web_view/_styles/tokens.css
@@ -1,0 +1,206 @@
+/*
+ * Ara mobile (web_view) design tokens.
+ *
+ * These mirror the Flutter app's `lib/constants/colors_info.dart` and the
+ * Pretendard typography stack defined in `pubspec.yaml`. They are scoped to
+ * `[data-ara-shell]` so they do not leak into the rest of the web app.
+ */
+
+[data-ara-shell] {
+    /* Brand */
+    --ara-primary: #ED3A3A;
+    --ara-primary-soft: #FF7070;
+    --ara-primary-bright: #FDF0F0;
+    --ara-positive: #ED3A3A;
+    --ara-negative: #538DD1;
+    --ara-neutral: #BBBBBB;
+
+    /* Surface */
+    --ara-bg: #FFFFFF;
+    --ara-bg-elevated: #FFFFFF;
+    --ara-bg-muted: #F7F7F7;
+    --ara-divider: #F0F0F0;
+    --ara-divider-strong: #DBDBDB;
+
+    /* Text */
+    --ara-text-primary: #111111;
+    --ara-text-secondary: #555555;
+    --ara-text-tertiary: #888888;
+    --ara-text-quaternary: #BBBBBB;
+    --ara-text-on-primary: #FFFFFF;
+
+    /* Layout */
+    --ara-tab-height: 56px;
+    --ara-header-height: 48px;
+    --ara-radius-sm: 8px;
+    --ara-radius-md: 12px;
+    --ara-radius-lg: 16px;
+    --ara-spacing-xs: 4px;
+    --ara-spacing-sm: 8px;
+    --ara-spacing-md: 12px;
+    --ara-spacing-lg: 16px;
+    --ara-spacing-xl: 20px;
+
+    /* Safe area — set by the layout from the bridge or visualViewport. */
+    --ara-safe-top: env(safe-area-inset-top, 0px);
+    --ara-safe-bottom: env(safe-area-inset-bottom, 0px);
+    --ara-safe-left: env(safe-area-inset-left, 0px);
+    --ara-safe-right: env(safe-area-inset-right, 0px);
+
+    /* Native keyboard height — overridden by the bridge / useKeyboard hook. */
+    --ara-keyboard-height: 0px;
+
+    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    color: var(--ara-text-primary);
+    background: var(--ara-bg);
+    -webkit-font-smoothing: antialiased;
+    -webkit-tap-highlight-color: transparent;
+    overscroll-behavior-y: contain;
+}
+
+[data-ara-shell] *,
+[data-ara-shell] *::before,
+[data-ara-shell] *::after {
+    box-sizing: border-box;
+}
+
+[data-ara-shell] .ara-screen {
+    min-height: 100vh;
+    min-height: 100dvh;
+    padding-top: var(--ara-safe-top);
+    padding-left: var(--ara-safe-left);
+    padding-right: var(--ara-safe-right);
+}
+
+[data-ara-shell] .ara-screen--with-tabbar {
+    padding-bottom: calc(var(--ara-tab-height) + var(--ara-safe-bottom));
+}
+
+[data-ara-shell] .ara-screen--no-tabbar {
+    padding-bottom: var(--ara-safe-bottom);
+}
+
+[data-ara-shell] .ara-tabbar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    align-items: stretch;
+    height: calc(var(--ara-tab-height) + var(--ara-safe-bottom));
+    padding-bottom: var(--ara-safe-bottom);
+    background: var(--ara-bg);
+    border-top: 1px solid var(--ara-divider);
+    z-index: 50;
+}
+
+[data-ara-shell] .ara-tabbar__btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 6px 4px;
+    color: var(--ara-text-tertiary);
+    font-size: 10px;
+    font-weight: 500;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+
+[data-ara-shell] .ara-tabbar__btn[data-active='true'] {
+    color: var(--ara-primary);
+}
+
+[data-ara-shell] .ara-tabbar__icon {
+    width: 24px;
+    height: 24px;
+}
+
+[data-ara-shell] .ara-header {
+    position: sticky;
+    top: 0;
+    height: var(--ara-header-height);
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    background: var(--ara-bg);
+    border-bottom: 1px solid var(--ara-divider);
+    z-index: 40;
+}
+
+[data-ara-shell] .ara-header__title {
+    flex: 1;
+    text-align: center;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--ara-text-primary);
+    margin: 0 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+[data-ara-shell] .ara-header__btn {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    color: var(--ara-text-primary);
+    cursor: pointer;
+}
+
+[data-ara-shell] .ara-card {
+    background: var(--ara-bg-elevated);
+    border: 1px solid var(--ara-divider);
+    border-radius: var(--ara-radius-md);
+    padding: var(--ara-spacing-lg);
+}
+
+[data-ara-shell] .ara-list-row {
+    display: flex;
+    align-items: center;
+    padding: var(--ara-spacing-md) var(--ara-spacing-lg);
+    border-bottom: 1px solid var(--ara-divider);
+    background: var(--ara-bg);
+    cursor: pointer;
+    -webkit-tap-highlight-color: rgba(237, 58, 58, 0.05);
+}
+
+[data-ara-shell] .ara-list-row:active {
+    background: var(--ara-bg-muted);
+}
+
+[data-ara-shell] .ara-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--ara-text-secondary);
+    background: var(--ara-bg-muted);
+}
+
+[data-ara-shell] .ara-pill--primary {
+    color: var(--ara-primary);
+    background: var(--ara-primary-bright);
+}
+
+[data-ara-shell] .ara-skeleton {
+    background: linear-gradient(90deg, #F0F0F0 0%, #F8F8F8 50%, #F0F0F0 100%);
+    background-size: 200% 100%;
+    animation: ara-skeleton-shimmer 1.4s ease-in-out infinite;
+    border-radius: var(--ara-radius-sm);
+}
+
+@keyframes ara-skeleton-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}

--- a/src/app/web_view/layout.tsx
+++ b/src/app/web_view/layout.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import './_styles/tokens.css';
+import { BottomTabBar, isTabRoot } from './_components/BottomTabBar';
+import { getBridge, useBridgeEvent } from './_bridge';
+import useKeyboard from './hooks/keyboard/useKeyboard';
+
+export default function WebViewLayout({ children }: { children: ReactNode }) {
+    const pathname = usePathname();
+    const router = useRouter();
+    const showTabBar = isTabRoot(pathname);
+
+    // Apply safe-area inset CSS vars from the bridge handshake (more reliable
+    // than env(safe-area-inset-*) inside a WebView on some devices).
+    useEffect(() => {
+        let cancelled = false;
+        getBridge()
+            .ready()
+            .then((cap) => {
+                if (cancelled || !cap) return;
+                const root = document.documentElement;
+                root.style.setProperty('--ara-safe-top', `${cap.safeArea.top}px`);
+                root.style.setProperty('--ara-safe-bottom', `${cap.safeArea.bottom}px`);
+                root.style.setProperty('--ara-safe-left', `${cap.safeArea.left}px`);
+                root.style.setProperty('--ara-safe-right', `${cap.safeArea.right}px`);
+                root.setAttribute('data-ara-platform', cap.platform);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    // Hardware back button on Android: navigate within the SPA history;
+    // native exits if the WebView reports it can't go back further.
+    useBridgeEvent('back:pressed', () => {
+        if (typeof window === 'undefined') return;
+        if (window.history.length > 1) {
+            router.back();
+        }
+    });
+
+    // Surface keyboard height as a CSS variable so any sticky element can
+    // lift above the keyboard via `bottom: var(--ara-keyboard-height)`.
+    // We trust the browser's visualViewport (via useKeyboard) on both
+    // platforms; the native `keyboard:changed` event is reserved for cases
+    // where the host wants to override (e.g. when pushing a native sheet).
+    const { keyboardHeight } = useKeyboard();
+    useEffect(() => {
+        document.documentElement.style.setProperty(
+            '--ara-keyboard-height',
+            `${keyboardHeight}px`,
+        );
+    }, [keyboardHeight]);
+    useBridgeEvent('keyboard:changed', (p) => {
+        document.documentElement.style.setProperty(
+            '--ara-keyboard-height',
+            `${p.height}px`,
+        );
+    });
+
+    // Mark the root with the shell attribute so tokens.css applies. We do
+    // this in an effect (not as a literal `<html data-ara-shell>`) because
+    // the html element is owned by the root layout.
+    const [shellApplied, setShellApplied] = useState(false);
+    useEffect(() => {
+        document.documentElement.setAttribute('data-ara-shell', '');
+        setShellApplied(true);
+        return () => {
+            document.documentElement.removeAttribute('data-ara-shell');
+            document.documentElement.style.removeProperty('--ara-safe-top');
+            document.documentElement.style.removeProperty('--ara-safe-bottom');
+            document.documentElement.style.removeProperty('--ara-safe-left');
+            document.documentElement.style.removeProperty('--ara-safe-right');
+            document.documentElement.style.removeProperty('--ara-keyboard-height');
+            document.documentElement.removeAttribute('data-ara-platform');
+        };
+    }, []);
+
+    return (
+        <>
+            <div suppressHydrationWarning>
+                {shellApplied ? children : children}
+            </div>
+            {showTabBar && <BottomTabBar />}
+        </>
+    );
+}


### PR DESCRIPTION
Flutter 앱을 단일 WebView 셸로 전환하는 작업의 웹 측 변경.
모든 신규/수정 파일은 src/app/web_view/ 안으로 격리되어
외부(컴포넌트/라이브러리/Tailwind 설정/패키지)는 건드리지 않음.

추가된 것:

* _bridge/ — WebView ↔ Native 메시지 프로토콜
  - PROTOCOL.md (사람이 읽는 spec)
  - types.ts (TS 타입을 spec의 단일 진실원으로 사용)
  - client.ts / useBridge.ts (window.AraBridge + React hooks)
* _components/ — Screen, AppHeader, BottomTabBar, StickyComposer (StickyComposer는 --ara-keyboard-height CSS var로 자동 키보드 회피)
* _styles/tokens.css — 앱 디자인 토큰 (data-ara-shell 스코프)
* layout.tsx — safe-area / 키보드 높이 / 하단탭 자동 표시

신규 라우트 (Flutter native 페이지 대응):
* Main, Board, Board/[slug] (홈 / 게시판 / 게시판 상세)
* Post/[id] (게시글 + 댓글 + 키보드 위로 뜨는 composer)
* Search, Notifications
* MyInfo, MyInfo/Edit, MyInfo/Settings, MyInfo/BlockedUsers
* User/[id], Login, Terms, Inquiry, Error

기존 web_view/Chat, Meal, PostFrame, PostWrite, hooks/ 는 유지.