### PR TITLE
Fix web_view app Routing

### DIFF
--- a/public/webview/icons/camera.svg
+++ b/public/webview/icons/camera.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="16" cy="16.5" r="4.5" stroke="black" stroke-width="2"/>
+<path d="M6 21V13.1875C6 11.5306 7.34315 10.1875 9 10.1875H10.9181C11.2701 10.1875 11.5556 9.90208 11.5556 9.55C11.5556 8.14167 12.6972 7 14.1056 7H17.8944C19.3028 7 20.4444 8.14167 20.4444 9.55C20.4444 9.90208 20.7299 10.1875 21.0819 10.1875H23C24.6569 10.1875 26 11.5306 26 13.1875V21C26 22.6569 24.6569 24 23 24H9C7.34315 24 6 22.6569 6 21Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="23" cy="13" r="1" fill="black"/>
+</svg>

--- a/src/app/web_view/Board/[slug]/page.tsx
+++ b/src/app/web_view/Board/[slug]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Screen, AppHeader, PostPreview, LeftChevronIcon, SearchIcon, PostIcon } from '@/app/web_view/_components';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import {
     fetchArticles,
     fetchTopArticles,
@@ -39,6 +40,7 @@ const SPECIAL_LABEL: Record<SpecialKind, string> = {
  */
 export default function BoardSlugPage() {
     const router = useRouter();
+    const onBack = useSafeBack();
     const params = useParams<{ slug: string }>();
     const rawSlug = decodeURIComponent(params.slug ?? '');
     const isSpecial = rawSlug.startsWith('_');
@@ -128,7 +130,7 @@ export default function BoardSlugPage() {
     const leading = (
         <button
             type="button"
-            onClick={() => router.back()}
+            onClick={onBack}
             className="flex items-center text-ara_red"
             aria-label="뒤로"
         >
@@ -164,7 +166,7 @@ export default function BoardSlugPage() {
                             onClick={() =>
                                 router.push(
                                     board
-                                        ? `/web_view/Search?board=${board.slug}`
+                                        ? `/web_view/Search?board=${board.id}`
                                         : '/web_view/Search',
                                 )
                             }

--- a/src/app/web_view/Chat/components/ChatRoomList.tsx
+++ b/src/app/web_view/Chat/components/ChatRoomList.tsx
@@ -86,7 +86,7 @@ export default function ChatRoomList({ onRoomClick }: ChatRoomListProps) {
             // 2. 성공하면 검색 다이얼로그를 닫습니다.
             setShowUserSearch(false);
             // 3. 생성된 채팅방으로 사용자를 이동시킵니다.
-            router.push(`/chat/${newRoom.id}`);
+            router.push(`/web_view/Chat/${newRoom.id}`);
         } catch (error: any) {
             // 4. 에러가 발생하면 (ex: 이미 채팅방이 존재) UserSearchDialog가
             //    에러 메시지를 alert로 띄워줄 수 있도록 에러를 다시 던집니다.

--- a/src/app/web_view/Inquiry/page.tsx
+++ b/src/app/web_view/Inquiry/page.tsx
@@ -1,36 +1,72 @@
 'use client';
 
-import { AppHeader, InformationIcon, Screen } from '@/app/web_view/_components';
+import { useEffect, useState } from 'react';
+import { LeftChevronIcon, Screen } from '@/app/web_view/_components';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
+import { fetchMe } from '@/lib/api/user';
+
+interface MeProfile {
+    id: number;
+    user?: number;
+    nickname?: string;
+    email?: string | null;
+}
 
 /**
- * Reached when an inactive / deleted account hits the app. Mirrors the
- * Flutter inquiry page: simple stacked text + a single brand-red CTA.
+ * Faithful port of `lib/pages/inquiry_page.dart` — the page shown when a
+ * previously-withdrawn account tries to log in again.
+ *
+ *   AppBar: red ‹ back, centered "문의 및 건의" 18/w700 ED3A3A.
+ *   Body: a centered red-bordered card whose entire 23/bold red text body
+ *         is tappable and opens a mailto: with the user's IDs prefilled.
  */
 export default function InquiryPage() {
-    const onMail = () => {
-        if (typeof window !== 'undefined') {
-            window.location.href = 'mailto:new-ara@sparcs.org';
-        }
+    const onBack = useSafeBack();
+    const [me, setMe] = useState<MeProfile | null>(null);
+
+    useEffect(() => {
+        fetchMe()
+            .then((data: MeProfile) => setMe(data))
+            .catch(() => {});
+    }, []);
+
+    const onContact = () => {
+        if (typeof window === 'undefined') return;
+        const userID = me?.user ?? me?.id ?? '';
+        const subject = '재가입 문의';
+        const body =
+            `추가로 말하실 말이 있다면 여기 아래에 적어주세요.\n\n` +
+            `※ Ara 관리자가 48시간 이내로 답변드립니다.※\n\n` +
+            `유저 번호: ${userID}\n닉네임: ${me?.nickname ?? ''}\n이메일: ${me?.email ?? ''}\n플랫폼: WebView\n`;
+        window.location.href =
+            `mailto:ara@sparcs.org?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     };
 
     return (
         <Screen withTabBar={false}>
-            <AppHeader title="문의" />
-            <div className="flex min-h-[calc(100dvh-56px)] flex-col items-center justify-center gap-5 px-6 text-center">
-                <span className="text-[#B1B1B1]">
-                    <InformationIcon size={50} />
-                </span>
-                <p className="m-0 max-w-[320px] text-[14px] leading-[1.7] text-[#646464]">
-                    탈퇴된 계정입니다. 자세한 내용은
-                    <br />
-                    new-ara@sparcs.org 로 문의해 주세요.
-                </p>
+            <header className="sticky top-0 z-40 flex h-14 items-center bg-white">
                 <button
                     type="button"
-                    onClick={onMail}
-                    className="h-[44px] rounded-[10px] bg-ara_red px-6 text-[14px] font-bold text-white"
+                    onClick={onBack}
+                    aria-label="뒤로"
+                    className="flex h-14 w-14 items-center justify-center text-ara_red"
                 >
-                    메일 보내기
+                    <LeftChevronIcon size={35} />
+                </button>
+                <h1 className="absolute left-0 right-0 mx-auto w-fit text-[18px] font-bold text-ara_red">
+                    문의 및 건의
+                </h1>
+            </header>
+
+            <div className="flex min-h-[calc(100dvh-56px)] items-center justify-center px-2 py-1">
+                <button
+                    type="button"
+                    onClick={onContact}
+                    className="block w-full rounded-lg border-[3.5px] border-ara_red bg-white px-2 py-1 text-left"
+                >
+                    <span className="block whitespace-pre-line text-[23px] font-bold leading-snug text-ara_red">
+                        {`이미 탈퇴 했던 계정입니다.\n재가입을 하고 싶다면 이 링크를 눌러 이메일로 문의하세요.`}
+                    </span>
                 </button>
             </div>
         </Screen>

--- a/src/app/web_view/Login/page.tsx
+++ b/src/app/web_view/Login/page.tsx
@@ -3,36 +3,46 @@
 import { AraLogo, Screen } from '@/app/web_view/_components';
 
 /**
- * SPARCS SSO entry. Mirrors the simple landing of `lib/pages/login_page.dart`:
- * centered ARA logo + a primary CTA button. No shadow, no border around
- * the button (just brand red).
+ * Faithful port of `lib/pages/login_page.dart`:
+ *
+ *   ┌──────────────────────────┐
+ *   │                          │
+ *   │     [ARA logo, 200w]     │  Expanded — fills the top region.
+ *   │                          │
+ *   │ ┌──────────────────────┐ │  300×60 button, 20px radius, ED3A3A,
+ *   │ │  SPARCS SSO로 로그인  │ │  label 18/w500 white.
+ *   │ └──────────────────────┘ │
+ *   │           50px           │  Fixed bottom gap.
+ *   └──────────────────────────┘
+ *
+ * SSO target uses the page's own origin so dev / prod / preview all work
+ * — Flutter goes through SparcsSSOPage; on the web we redirect to the
+ * Django SSO endpoint and let it bounce us back to /web_view/Main.
  */
 export default function LoginPage() {
     const onSsoLogin = () => {
-        const apiHost = process.env.NEXT_PUBLIC_API_HOST || 'https://newara.dev.sparcs.org';
-        const next = encodeURIComponent('https://newara.dev.sparcs.org/web_view/Main');
-        window.location.href = `${apiHost}/api/users/sso_login/?next=${next}`;
+        if (typeof window === 'undefined') return;
+        const apiHost =
+            process.env.NEXT_PUBLIC_API_HOST?.replace(/\/$/, '') ||
+            window.location.origin;
+        const next = `${window.location.origin}/web_view/Main`;
+        window.location.href = `${apiHost}/api/users/sso_login/?next=${encodeURIComponent(next)}`;
     };
 
     return (
         <Screen withTabBar={false}>
-            <div className="flex min-h-[100dvh] flex-col items-center justify-center px-6">
-                <div className="flex-1" />
-                <AraLogo width={140} height={76} />
-                <div className="mt-3 text-[16px] font-medium text-[#B1B1B1]">
-                    KAIST 학생 커뮤니티
+            <div className="flex min-h-[100dvh] flex-col items-center px-6">
+                <div className="flex w-full flex-1 items-center justify-center">
+                    <AraLogo width={200} height={109} />
                 </div>
-                <div className="flex-1" />
-
                 <button
                     type="button"
                     onClick={onSsoLogin}
-                    className="h-[50px] w-full max-w-[320px] rounded-[10px] bg-ara_red text-[15px] font-bold text-white"
+                    className="flex h-[60px] w-[300px] items-center justify-center rounded-[20px] bg-ara_red text-[18px] font-medium text-white"
                 >
-                    SPARCS SSO 로그인
+                    SPARCS SSO로 로그인
                 </button>
-
-                <footer className="mt-8 text-[12px] text-[#B1B1B1]">© SPARCS Ara</footer>
+                <div className="h-[50px]" />
             </div>
         </Screen>
     );

--- a/src/app/web_view/Main/_components/HomeAppBar.tsx
+++ b/src/app/web_view/Main/_components/HomeAppBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { AraLogo, LanguageIcon, PostIcon, SearchIcon } from '@/app/web_view/_components';
+import { AraLogo, PostIcon, SearchIcon } from '@/app/web_view/_components';
 
 /**
  * Mirrors the AppBar in `main_page.dart`: 56px tall, ARA logo on the left,
@@ -14,13 +14,6 @@ export function HomeAppBar() {
         <header className="sticky top-0 z-40 flex h-14 items-center bg-white px-4">
             <AraLogo width={68} height={37} />
             <div className="ml-auto flex items-center gap-1">
-                <button
-                    type="button"
-                    aria-label="언어"
-                    className="flex h-11 w-11 items-center justify-center text-ara_red"
-                >
-                    <LanguageIcon size={24} />
-                </button>
                 <button
                     type="button"
                     aria-label="글쓰기"

--- a/src/app/web_view/MyInfo/BlockedUsers/page.tsx
+++ b/src/app/web_view/MyInfo/BlockedUsers/page.tsx
@@ -1,23 +1,51 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { AppHeader, Screen } from '@/app/web_view/_components';
+import {
+    Close2Icon,
+    LeftChevronIcon,
+    Screen,
+    WarningIcon,
+} from '@/app/web_view/_components';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import { deleteBlock, fetchBlocks } from '@/lib/api/user';
+
+interface BlockUserProfile {
+    nickname?: string | null;
+    picture?: string | null;
+}
 
 interface BlockItem {
     id: number;
-    blocked_nickname?: string;
-    user?: { nickname?: string } | null;
-    blocked?: { nickname?: string } | null;
+    user?: { profile?: BlockUserProfile } | null;
+    blocked?: { profile?: BlockUserProfile } | null;
+    blocked_nickname?: string | null;
+    blocked_picture?: string | null;
 }
 
-function getBlockedName(b: BlockItem): string {
+function pickProfile(b: BlockItem): BlockUserProfile {
     return (
-        b.blocked_nickname ?? b.blocked?.nickname ?? b.user?.nickname ?? '알 수 없음'
+        b.blocked?.profile ??
+        b.user?.profile ??
+        ({
+            nickname: b.blocked_nickname ?? null,
+            picture: b.blocked_picture ?? null,
+        } as BlockUserProfile)
     );
 }
 
+/**
+ * Faithful port of the `BlockedUserDialog` body in `lib/widgets/dialogs.dart`,
+ * adapted from a modal dialog into a dedicated route — modals are awkward in
+ * the WebView shell.
+ *
+ *   AppBar : red ‹ back, centered "차단한 유저 목록" 18/w700 ED3A3A.
+ *   List   : 50px rows — 40×40 grey avatar (or warning.svg fallback) ─20px─
+ *            nickname 15/w500  ─flex─  close-2 25×25 unblock icon.
+ *   Empty  : "차단된 사용자가 없습니다." 15/w500 black centered.
+ */
 export default function BlockedUsersPage() {
+    const onBack = useSafeBack();
     const [items, setItems] = useState<BlockItem[]>([]);
     const [loading, setLoading] = useState(true);
     const [removing, setRemoving] = useState<number | null>(null);
@@ -57,36 +85,70 @@ export default function BlockedUsersPage() {
 
     return (
         <Screen withTabBar={false}>
-            <AppHeader title="차단된 사용자" />
+            <header className="sticky top-0 z-40 flex h-14 items-center bg-white">
+                <button
+                    type="button"
+                    onClick={onBack}
+                    aria-label="뒤로"
+                    className="flex h-14 w-14 items-center justify-center text-ara_red"
+                >
+                    <LeftChevronIcon size={35} />
+                </button>
+                <h1 className="absolute left-0 right-0 mx-auto w-fit text-[18px] font-bold text-ara_red">
+                    차단한 유저 목록
+                </h1>
+            </header>
 
             {loading ? (
                 <div className="flex justify-center py-6 text-[12px] text-[#B1B1B1]">
                     불러오는 중...
                 </div>
             ) : items.length === 0 ? (
-                <div className="px-6 py-16 text-center text-[14px] text-[#B1B1B1]">
+                <div className="flex h-[55px] items-center justify-center text-[15px] font-medium text-black">
                     차단된 사용자가 없습니다.
                 </div>
             ) : (
-                <ul className="px-5">
-                    {items.map((b) => (
-                        <li
-                            key={b.id}
-                            className="flex h-[50px] items-center border-b border-[#F0F0F0]"
-                        >
-                            <span className="flex-1 text-[14px] text-black">
-                                {getBlockedName(b)}
-                            </span>
-                            <button
-                                type="button"
-                                onClick={() => onUnblock(b.id)}
-                                disabled={removing === b.id}
-                                className="rounded-full border border-[#F0F0F0] bg-white px-3 py-1 text-[12px] font-medium text-[#646464] disabled:text-[#B1B1B1]"
-                            >
-                                {removing === b.id ? '처리 중...' : '차단 해제'}
-                            </button>
-                        </li>
-                    ))}
+                <ul className="px-[15px]">
+                    {items.map((b, idx) => {
+                        const profile = pickProfile(b);
+                        return (
+                            <li key={b.id}>
+                                <div className="flex h-[50px] items-center">
+                                    <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#9E9E9E] text-white">
+                                        {profile.picture ? (
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img
+                                                src={profile.picture}
+                                                alt=""
+                                                className="h-full w-full object-cover"
+                                                onError={(e) => {
+                                                    (e.currentTarget as HTMLImageElement).style.display = 'none';
+                                                }}
+                                            />
+                                        ) : (
+                                            <WarningIcon size={35} />
+                                        )}
+                                    </span>
+                                    <div className="w-5" />
+                                    <span className="flex-1 truncate text-[15px] font-medium text-black">
+                                        {profile.nickname ?? '닉네임 없음'}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        onClick={() => onUnblock(b.id)}
+                                        disabled={removing === b.id}
+                                        aria-label="차단 해제"
+                                        className="flex h-10 w-10 items-center justify-center bg-transparent text-black disabled:opacity-50"
+                                    >
+                                        <Close2Icon size={25} />
+                                    </button>
+                                </div>
+                                {idx < items.length - 1 && (
+                                    <div className="h-px bg-[#F0F0F0]" />
+                                )}
+                            </li>
+                        );
+                    })}
                 </ul>
             )}
         </Screen>

--- a/src/app/web_view/MyInfo/Edit/page.tsx
+++ b/src/app/web_view/MyInfo/Edit/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { AppHeader, Screen } from '@/app/web_view/_components';
+import {
+    CameraIcon,
+    LeftChevronIcon,
+    Screen,
+} from '@/app/web_view/_components';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import { fetchMe, updateUser } from '@/lib/api/user';
 
 interface MeProfile {
@@ -10,17 +14,28 @@ interface MeProfile {
     user?: number;
     nickname?: string;
     picture?: string | null;
+    email?: string | null;
     see_sexual?: boolean;
     see_social?: boolean;
 }
 
 /**
- * Mirrors `lib/pages/profile_edit_page.dart`. A round 96px avatar at the
- * top, "변경" button, a single nickname text field, and a sticky red
- * 저장 CTA at the bottom.
+ * Faithful port of `lib/pages/profile_edit_page.dart`.
+ *
+ *   AppBar: red ‹ back · centered "프로필 수정" 18/w700 · "완료" 17/w500 right.
+ *   Body:
+ *     - 10px gap
+ *     - Round avatar (width-70 diameter), grey 1px border, with a 40×40
+ *       black "camera" badge at bottom:0 right:50.
+ *     - 40px gap
+ *     - Row (width-60): "닉네임" 17/w700 #636363  ─30px─  filled input
+ *       (#EBEBEB, 10px radius, 15px left padding).
+ *     - Helper text 12/w600 #BFBFBF, 80px left padding.
+ *     - 30px gap
+ *     - Row (width-60): "이메일" 17/w700 #636363  ─45px─  email 15/w500 #B1B1B1.
  */
 export default function ProfileEditPage() {
-    const router = useRouter();
+    const onBack = useSafeBack();
     const fileRef = useRef<HTMLInputElement | null>(null);
     const [me, setMe] = useState<MeProfile | null>(null);
     const [nickname, setNickname] = useState('');
@@ -50,21 +65,27 @@ export default function ProfileEditPage() {
         setPictureFile(f);
     };
 
-    const onSave = async () => {
-        if (!me?.id || saving) return;
+    const onSubmit = async () => {
+        if (!me?.user && !me?.id) return;
+        const userId = (me.user ?? me.id) as number;
+        const trimmed = nickname.trim();
+        if (!trimmed) {
+            if (typeof window !== 'undefined') window.alert('닉네임이 작성되지 않았습니다!');
+            return;
+        }
         setSaving(true);
         try {
-            await updateUser(me.id, {
-                nickname: nickname.trim(),
+            await updateUser(userId, {
+                nickname: trimmed,
                 picture: pictureFile,
                 sexual: Boolean(me.see_sexual),
                 social: Boolean(me.see_social),
             });
-            router.back();
+            onBack();
         } catch (e) {
             console.warn('updateUser failed', e);
             if (typeof window !== 'undefined') {
-                window.alert('저장에 실패했어요. 잠시 후 다시 시도해 주세요.');
+                window.alert('설정 변경 중 문제가 발생했습니다.');
             }
         } finally {
             setSaving(false);
@@ -73,60 +94,95 @@ export default function ProfileEditPage() {
 
     return (
         <Screen withTabBar={false}>
-            <AppHeader title="프로필 수정" />
-
-            <div className="flex flex-col items-center gap-3 px-5 pt-8 pb-4">
-                <span
-                    className="inline-flex h-[96px] w-[96px] items-center justify-center overflow-hidden rounded-full bg-[#E5E5E5]"
-                    aria-hidden
-                >
-                    {previewUrl && (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={previewUrl} alt="" className="h-full w-full object-cover" />
-                    )}
-                </span>
+            <header className="sticky top-0 z-40 flex h-14 items-center bg-white">
                 <button
                     type="button"
-                    onClick={() => fileRef.current?.click()}
-                    className="bg-transparent text-[13px] font-medium text-ara_red"
+                    onClick={onBack}
+                    aria-label="뒤로"
+                    className="flex h-14 w-14 items-center justify-center text-ara_red"
                 >
-                    변경
+                    <LeftChevronIcon size={35} />
                 </button>
-                <input
-                    ref={fileRef}
-                    type="file"
-                    accept="image/*"
-                    className="hidden"
-                    onChange={onPickFile}
-                />
-            </div>
-
-            <label className="block px-5 pb-1 text-[12px] text-[#646464]">닉네임</label>
-            <div className="px-5">
-                <input
-                    type="text"
-                    value={nickname}
-                    onChange={(e) => setNickname(e.target.value)}
-                    placeholder="닉네임을 입력하세요"
-                    className="block w-full rounded-[10px] bg-[#F8F8F8] px-3 py-3 text-[14px] text-black placeholder:text-[#BBBBBB] focus:outline-none"
-                />
-            </div>
-
-            <div
-                className="fixed inset-x-0 z-30 bg-white px-5 pt-3"
-                style={{
-                    bottom: 0,
-                    paddingBottom: 'calc(12px + var(--ara-safe-bottom))',
-                }}
-            >
+                <h1 className="absolute left-0 right-0 mx-auto w-fit text-[18px] font-bold text-ara_red">
+                    프로필 수정
+                </h1>
                 <button
                     type="button"
-                    onClick={onSave}
-                    disabled={saving || !nickname.trim()}
-                    className="block h-[50px] w-full rounded-[10px] bg-ara_red text-[15px] font-bold text-white disabled:bg-ara_red_bright"
+                    onClick={onSubmit}
+                    disabled={saving}
+                    className="ml-auto px-[15px] text-[17px] font-medium text-ara_red disabled:opacity-50"
                 >
-                    {saving ? '저장 중...' : '저장'}
+                    완료
                 </button>
+            </header>
+
+            <div className="flex flex-col items-center">
+                <div className="h-[10px]" />
+
+                {/* Round avatar with camera badge — width-70 diameter. */}
+                <div
+                    className="relative"
+                    style={{ width: 'calc(100vw - 70px)', height: 'calc(100vw - 70px)', maxWidth: 320, maxHeight: 320 }}
+                >
+                    <div className="h-full w-full overflow-hidden rounded-full border border-[#9E9E9E] bg-[#E5E5E5]">
+                        {previewUrl && (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                                src={previewUrl}
+                                alt=""
+                                className="h-full w-full object-cover"
+                                draggable={false}
+                            />
+                        )}
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => fileRef.current?.click()}
+                        aria-label="프로필 사진 변경"
+                        className="absolute bottom-0 right-[50px] flex h-10 w-10 items-center justify-center rounded-full bg-[#333333] text-white"
+                    >
+                        <CameraIcon size={20} />
+                    </button>
+                    <input
+                        ref={fileRef}
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={onPickFile}
+                    />
+                </div>
+
+                <div className="h-10" />
+
+                {/* Nickname row */}
+                <div className="flex w-[calc(100%-60px)] items-center">
+                    <span className="text-[17px] font-bold text-[#636363]">닉네임</span>
+                    <div className="w-[30px]" />
+                    <div className="flex-1 rounded-[10px] bg-[#EBEBEB]">
+                        <input
+                            type="text"
+                            value={nickname}
+                            onChange={(e) => setNickname(e.target.value)}
+                            placeholder="변경하실 닉네임을 입력해주세요."
+                            className="block h-[44px] w-full bg-transparent pl-[15px] text-[15px] text-black placeholder:text-[#9E9E9E] focus:outline-none"
+                        />
+                    </div>
+                </div>
+
+                <div className="w-[calc(100%-60px)] pl-[80px] pt-[6px] text-[12px] font-semibold text-[#BFBFBF]">
+                    닉네임은 한번 변경할 시 3개월간 변경이 불가합니다.
+                </div>
+
+                <div className="h-[30px]" />
+
+                {/* Email row — read-only display. */}
+                <div className="flex w-[calc(100%-60px)] items-center">
+                    <span className="text-[17px] font-bold text-[#636363]">이메일</span>
+                    <div className="w-[45px]" />
+                    <span className="flex-1 truncate text-[15px] font-medium text-[#B1B1B1]">
+                        {me?.email ?? '이메일 정보가 없습니다.'}
+                    </span>
+                </div>
             </div>
         </Screen>
     );

--- a/src/app/web_view/MyInfo/Settings/page.tsx
+++ b/src/app/web_view/MyInfo/Settings/page.tsx
@@ -2,67 +2,92 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { AppHeader, RightChevronIcon, Screen } from '@/app/web_view/_components';
-import { bridge, getBridge } from '@/app/web_view/_bridge';
-import { fetchMe, logout, updateDarkMode } from '@/lib/api/user';
+import {
+    BarriorIcon,
+    InformationIcon,
+    LeftChevronIcon,
+    PostListIcon,
+    RightChevronIcon,
+    Screen,
+} from '@/app/web_view/_components';
+import { bridge } from '@/app/web_view/_bridge';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
+import http from '@/lib/api/http';
+import { fetchMe, logout } from '@/lib/api/user';
 
 interface MeProfile {
     id: number;
     user?: number;
-    extra_preferences?: { darkMode?: boolean } | null;
+    nickname?: string;
+    email?: string | null;
+    see_sexual?: boolean;
+    see_social?: boolean;
 }
 
 /**
- * Mirrors `lib/pages/setting_page.dart`. List of plain rows separated by
- * 1px hairlines — no shadow on the page itself, no border on the rows.
+ * Faithful port of `lib/pages/setting_page.dart`.
+ *
+ *   1.  AppBar with red chevron + centered red "설정" 18/w700.
+ *   2.  Section header (icon + 18/w700 black) followed by a (width-40) box
+ *       with 1px #F0F0F0 border and 10px radius. Same recipe for 게시글 /
+ *       차단 / 정보.
+ *   3.  TextInfo: 12/w500 #BFBFBF helper line, width-60.
+ *   4.  Two standalone red CTA boxes (로그아웃 / 회원탈퇴) each 50px tall.
  */
 export default function SettingsPage() {
     const router = useRouter();
+    const onBack = useSafeBack();
     const [me, setMe] = useState<MeProfile | null>(null);
-    const [dark, setDark] = useState(false);
-    const [appVersion, setAppVersion] = useState<string>('web');
+    const [seeSexual, setSeeSexual] = useState(true);
+    const [seeSocial, setSeeSocial] = useState(true);
 
     useEffect(() => {
         fetchMe()
             .then((data: MeProfile) => {
                 setMe(data);
-                setDark(Boolean(data?.extra_preferences?.darkMode));
+                setSeeSexual(data?.see_sexual ?? true);
+                setSeeSocial(data?.see_social ?? true);
             })
             .catch((e) => console.warn('fetchMe failed', e));
     }, []);
 
-    useEffect(() => {
-        let cancelled = false;
-        getBridge()
-            .ready()
-            .then((cap) => {
-                if (cancelled) return;
-                if (cap?.appVersion) setAppVersion(cap.appVersion);
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, []);
+    const userId = me?.user ?? me?.id;
 
-    const onToggleDark = async (next: boolean) => {
-        setDark(next);
+    const patchPreference = async (
+        key: 'see_sexual' | 'see_social',
+        value: boolean,
+    ) => {
+        if (!userId) return false;
         try {
-            if (me?.id) await updateDarkMode(me.id, next);
+            await http.patch(`/user_profiles/${userId}/`, { [key]: value });
+            return true;
         } catch (e) {
-            console.warn('updateDarkMode failed', e);
-            setDark(!next);
+            console.warn('patch preference failed', e);
+            return false;
         }
     };
 
-    const onMail = () => {
+    const onToggleSexual = async (next: boolean) => {
+        setSeeSexual(next);
+        const ok = await patchPreference('see_sexual', next);
+        if (!ok) setSeeSexual(!next);
+    };
+    const onToggleSocial = async (next: boolean) => {
+        setSeeSocial(next);
+        const ok = await patchPreference('see_social', next);
+        if (!ok) setSeeSocial(!next);
+    };
+
+    const onContact = () => {
         if (typeof window !== 'undefined') {
-            window.location.href = 'mailto:new-ara@sparcs.org';
+            window.location.href = 'mailto:ara@sparcs.org';
         }
     };
 
     const onLogout = async () => {
+        if (typeof window !== 'undefined' && !window.confirm('로그아웃 하시겠습니까?')) return;
         try {
-            if (me?.user ?? me?.id) await logout((me?.user ?? me?.id) as number);
+            if (userId) await logout(userId);
         } catch (e) {
             console.warn('logout failed', e);
         }
@@ -74,84 +99,246 @@ export default function SettingsPage() {
         router.replace('/web_view/Login');
     };
 
+    const onWithdraw = () => {
+        if (typeof window === 'undefined') return;
+        const body =
+            `유저 번호: ${userId ?? ''}\n닉네임: ${me?.nickname ?? ''}\n이메일: ${me?.email ?? ''}\n` +
+            `탈퇴 요청드립니다(Ara 관리자가 확인 후 처리해드리며 조금의 시간이 소요될 수 있습니다)`;
+        const url =
+            'mailto:ara@sparcs.org' +
+            `?subject=${encodeURIComponent('Ara 회원 탈퇴 요청')}` +
+            `&body=${encodeURIComponent(body)}`;
+        window.location.href = url;
+    };
+
     return (
         <Screen withTabBar={false}>
-            <AppHeader title="설정" />
-
-            <ul className="px-5">
-                <Row label="다크 모드">
-                    <Toggle checked={dark} onChange={onToggleDark} />
-                </Row>
-                <Row label="차단된 사용자" onClick={() => router.push('/web_view/MyInfo/BlockedUsers')}>
-                    <span className="text-[#9E9E9E]">
-                        <RightChevronIcon size={16} />
-                    </span>
-                </Row>
-                <Row label="이용약관" onClick={() => router.push('/web_view/Terms')}>
-                    <span className="text-[#9E9E9E]">
-                        <RightChevronIcon size={16} />
-                    </span>
-                </Row>
-                <Row label="문의하기" onClick={onMail}>
-                    <span className="text-[#9E9E9E]">
-                        <RightChevronIcon size={16} />
-                    </span>
-                </Row>
-                <Row label="버전">
-                    <span className="text-[13px] text-[#B1B1B1]">{appVersion}</span>
-                </Row>
-
-                <li
-                    onClick={onLogout}
-                    role="button"
-                    className="mt-6 flex h-[50px] cursor-pointer items-center"
+            {/* Header — centered title with red back chevron. */}
+            <header className="sticky top-0 z-40 flex h-14 items-center bg-white">
+                <button
+                    type="button"
+                    onClick={onBack}
+                    aria-label="뒤로"
+                    className="flex h-14 w-14 items-center justify-center text-ara_red"
                 >
-                    <span className="text-[15px] font-medium text-ara_red">로그아웃</span>
-                </li>
-            </ul>
+                    <LeftChevronIcon size={35} />
+                </button>
+                <h1 className="absolute left-0 right-0 mx-auto w-fit text-[18px] font-bold text-ara_red">
+                    설정
+                </h1>
+            </header>
+
+            <div className="flex flex-col items-center pb-10">
+                <div className="h-[23px]" />
+
+                {/* 게시글 설정 */}
+                <SectionHeader
+                    icon={<PostListIcon size={34} className="text-black" />}
+                    label="게시글 설정"
+                />
+                <div className="h-[7px]" />
+                <BoxRow height={94}>
+                    <ToggleRow
+                        label="성인글 보기"
+                        checked={seeSexual}
+                        onChange={onToggleSexual}
+                    />
+                    <div className="h-4" />
+                    <ToggleRow
+                        label="정치글 보기"
+                        checked={seeSocial}
+                        onChange={onToggleSocial}
+                    />
+                </BoxRow>
+
+                <div className="h-6" />
+
+                {/* 차단 */}
+                <SectionHeader
+                    icon={<BarriorIcon size={34} className="text-black" />}
+                    label="차단"
+                />
+                <div className="h-[7px]" />
+                <BoxRow
+                    height={50}
+                    onClick={() => router.push('/web_view/MyInfo/BlockedUsers')}
+                    centered
+                >
+                    <span className="text-[16px] font-medium text-ara_red">
+                        차단한 유저 목록
+                    </span>
+                </BoxRow>
+                <div className="h-[5px]" />
+                <TextInfo>
+                    유저 차단은 게시글의 &lsquo;더보기&rsquo; 기능에서 하실 수 있습니다. 하루에 최대 10번만 변경 가능합니다.
+                </TextInfo>
+
+                <div className="h-5" />
+
+                {/* 정보 */}
+                <SectionHeader
+                    icon={<InformationIcon size={36} className="text-black" />}
+                    label="정보"
+                />
+                <div className="h-[7px]" />
+                <BoxRow height={134}>
+                    {/* 다크 모드 — disabled (Beta) */}
+                    <div className="flex items-center justify-between">
+                        <div className="ml-[10px] flex items-center">
+                            <span className="text-[16px] font-medium text-[#9E9E9E]">
+                                다크 모드
+                            </span>
+                            <span className="ml-[6px] rounded-md bg-[#E5E5E5] px-[6px] py-[2px] text-[10px] font-semibold text-[#646464]">
+                                Beta 준비중
+                            </span>
+                        </div>
+                        <span className="mr-[10px] inline-block opacity-40">
+                            <Toggle checked={false} disabled onChange={() => {}} />
+                        </span>
+                    </div>
+                    <div className="h-4" />
+                    {/* 이용약관 */}
+                    <RowLink
+                        label="이용약관"
+                        onClick={() => router.push('/web_view/Terms')}
+                    />
+                    <div className="h-4" />
+                    {/* 문의 */}
+                    <RowLink label="운영진에게 문의하기" onClick={onContact} />
+                </BoxRow>
+
+                <div className="h-5" />
+
+                <BoxRow height={50} onClick={onLogout} centered>
+                    <span className="text-[16px] font-medium text-ara_red">
+                        로그아웃
+                    </span>
+                </BoxRow>
+
+                <div className="h-5" />
+
+                <BoxRow height={50} onClick={onWithdraw} centered>
+                    <span className="text-[16px] font-medium text-ara_red">
+                        회원탈퇴
+                    </span>
+                </BoxRow>
+                <div className="h-[5px]" />
+                <TextInfo>
+                    회원 탈퇴는 Ara 관리자가 확인 후 처리해드리며, 최대 24시간이 소요될 수 있습니다.
+                </TextInfo>
+            </div>
         </Screen>
     );
 }
 
-function Row({
-    label,
-    onClick,
-    children,
-}: {
-    label: string;
-    onClick?: () => void;
-    children?: React.ReactNode;
-}) {
+/* =========================================================================
+ * Section building blocks — width-40 box with 1px hairline + 10px radius.
+ * ========================================================================= */
+
+function SectionHeader({ icon, label }: { icon: React.ReactNode; label: string }) {
     return (
-        <li
-            onClick={onClick}
-            role={onClick ? 'button' : undefined}
-            className={[
-                'flex h-[50px] items-center border-b border-[#F0F0F0]',
-                onClick ? 'cursor-pointer' : 'cursor-default',
-            ].join(' ')}
-        >
-            <span className="flex-1 text-[14px] text-black">{label}</span>
-            {children}
-        </li>
+        <div className="flex w-[calc(100%-50px)] items-center">
+            <span className="inline-flex items-center justify-center">{icon}</span>
+            <span className="text-[18px] font-bold text-black">{label}</span>
+        </div>
     );
 }
 
-function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+function BoxRow({
+    height,
+    children,
+    onClick,
+    centered = false,
+}: {
+    height: number;
+    children: React.ReactNode;
+    onClick?: () => void;
+    centered?: boolean;
+}) {
+    const Tag = onClick ? 'button' : 'div';
+    return (
+        <Tag
+            type={onClick ? 'button' : undefined}
+            onClick={onClick}
+            className={[
+                'w-[calc(100%-40px)] rounded-[10px] border border-[#F0F0F0] bg-transparent',
+                centered ? 'flex items-center justify-center' : 'flex flex-col justify-center',
+            ].join(' ')}
+            style={{ height }}
+        >
+            {children}
+        </Tag>
+    );
+}
+
+function TextInfo({ children }: { children: React.ReactNode }) {
+    return (
+        <p className="w-[calc(100%-60px)] text-[12px] font-medium text-[#BFBFBF]">
+            {children}
+        </p>
+    );
+}
+
+function ToggleRow({
+    label,
+    checked,
+    onChange,
+}: {
+    label: string;
+    checked: boolean;
+    onChange: (v: boolean) => void;
+}) {
+    return (
+        <div className="flex items-center justify-between">
+            <span className="ml-[10px] text-[16px] font-medium text-black">{label}</span>
+            <span className="mr-[10px] inline-block">
+                <Toggle checked={checked} onChange={onChange} />
+            </span>
+        </div>
+    );
+}
+
+function RowLink({ label, onClick }: { label: string; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex w-full items-center justify-between bg-transparent"
+        >
+            <span className="ml-[10px] text-[16px] font-medium text-black">{label}</span>
+            <span className="mr-[10px] inline-flex text-black">
+                <RightChevronIcon size={20} />
+            </span>
+        </button>
+    );
+}
+
+/** 43×27 Cupertino-style switch with brand red active state. */
+function Toggle({
+    checked,
+    onChange,
+    disabled = false,
+}: {
+    checked: boolean;
+    onChange: (v: boolean) => void;
+    disabled?: boolean;
+}) {
     return (
         <button
             type="button"
             role="switch"
             aria-checked={checked}
-            onClick={() => onChange(!checked)}
+            disabled={disabled}
+            onClick={() => !disabled && onChange(!checked)}
             className={[
-                'relative h-6 w-10 rounded-full p-0 transition-colors',
+                'relative h-[27px] w-[43px] rounded-full p-0 transition-colors',
                 checked ? 'bg-ara_red' : 'bg-[#E5E5E5]',
+                disabled ? 'cursor-not-allowed' : '',
             ].join(' ')}
         >
             <span
                 aria-hidden
-                className="absolute top-0.5 h-5 w-5 rounded-full bg-white transition-[left]"
+                className="absolute top-[2px] block h-[23px] w-[23px] rounded-full bg-white shadow transition-[left]"
                 style={{ left: checked ? 18 : 2 }}
             />
         </button>

--- a/src/app/web_view/Post/[id]/_components/Attachments.tsx
+++ b/src/app/web_view/Post/[id]/_components/Attachments.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ClipBadgeIcon } from '@/app/web_view/_components';
+import { bridge } from '@/app/web_view/_bridge';
 
 type RawAttachment = {
     id: number;
@@ -26,6 +27,22 @@ export function Attachments({ attachments }: AttachmentsProps) {
     const images = attachments.filter((a) => isImage(a.mimetype));
     const files = attachments.filter((a) => !isImage(a.mimetype));
 
+    // <a target="_blank"> would replace the WebView document on tap (there
+    // are no real "new tabs" inside the shell). Route through the bridge
+    // so the host opens the file URL externally — same pattern as ContentArea.
+    const onFileClick = (e: React.MouseEvent<HTMLAnchorElement>, url: string) => {
+        e.preventDefault();
+        try {
+            bridge?.send('openExternal', { url });
+            return;
+        } catch {
+            /* fall through */
+        }
+        if (typeof window !== 'undefined') {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        }
+    };
+
     return (
         <div className="flex flex-col gap-3 px-5">
             {images.map((img) => (
@@ -47,6 +64,7 @@ export function Attachments({ attachments }: AttachmentsProps) {
                                     href={f.file}
                                     target="_blank"
                                     rel="noreferrer noopener"
+                                    onClick={(e) => onFileClick(e, f.file)}
                                     className="flex items-center gap-[10px] rounded-[10px] border border-[#F0F0F0] bg-[#FAFAFA] p-3 text-[13px] text-black"
                                 >
                                     <span className="shrink-0 text-[#666666]">

--- a/src/app/web_view/Post/[id]/page.tsx
+++ b/src/app/web_view/Post/[id]/page.tsx
@@ -12,7 +12,8 @@ import {
 import { formatPost } from '@/app/post/util/getPost';
 import TextEditor from '@/components/TextEditor/TextEditor';
 import type { Comment, PostData } from '@/lib/types/post';
-import { AppHeader, LeftChevronIcon, Screen } from '@/app/web_view/_components';
+import { AppHeader, ContentArea, LeftChevronIcon, Screen } from '@/app/web_view/_components';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import { ArticleHeader } from './_components/ArticleHeader';
 import { Attachments } from './_components/Attachments';
 import { CommentComposer } from './_components/CommentComposer';
@@ -25,6 +26,7 @@ type VoteAction = 'vote_positive' | 'vote_negative' | 'vote_cancel';
 export default function WebViewPostDetailPage() {
     const params = useParams();
     const router = useRouter();
+    const onBack = useSafeBack();
     const idRaw = (params?.id ?? '') as string;
     const postId = Number.parseInt(idRaw, 10);
 
@@ -153,7 +155,7 @@ export default function WebViewPostDetailPage() {
 
     const handleEdit = () => {
         if (!post) return;
-        router.push(`/web_view/PostWrite?id=${post.id}`);
+        router.push(`/web_view/PostWrite?edit=${post.id}`);
     };
 
     const handleDelete = async () => {
@@ -162,7 +164,7 @@ export default function WebViewPostDetailPage() {
         try {
             const { deletePost } = await import('@/lib/api/post');
             await deletePost(post.id);
-            router.back();
+            onBack();
         } catch (e) {
             console.warn('deletePost failed', e);
         }
@@ -199,7 +201,7 @@ export default function WebViewPostDetailPage() {
     const leading = (
         <button
             type="button"
-            onClick={() => router.back()}
+            onClick={onBack}
             className="flex items-center text-ara_red"
             aria-label="뒤로"
         >
@@ -214,10 +216,11 @@ export default function WebViewPostDetailPage() {
 
             <ArticleHeader post={post} />
 
-            {/* Article body */}
-            <section className="px-5 pt-[10px] text-[15px] leading-relaxed text-black">
+            {/* Article body — anchor clicks are intercepted so external URLs
+                open via the bridge instead of replacing the WebView. */}
+            <ContentArea className="px-5 pt-[10px] text-[15px] leading-relaxed text-black">
                 <TextEditor content={post.content} editable={false} />
-            </section>
+            </ContentArea>
 
             {post.attachments && post.attachments.length > 0 && (
                 <div className="pt-3">

--- a/src/app/web_view/Terms/page.tsx
+++ b/src/app/web_view/Terms/page.tsx
@@ -2,37 +2,68 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { AppHeader, Screen } from '@/app/web_view/_components';
+import { LeftChevronIcon, Screen } from '@/app/web_view/_components';
+import { bridge } from '@/app/web_view/_bridge';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import { fetchMe, updateTos } from '@/lib/api/user';
-import { tosContent } from '@/app/tos/content';
+
+function openExternal(url: string) {
+    try {
+        bridge?.send('openExternal', { url });
+        return;
+    } catch {
+        /* fall through */
+    }
+    if (typeof window !== 'undefined') {
+        window.open(url, '_blank', 'noopener,noreferrer');
+    }
+}
+
+interface MeProfile {
+    id: number;
+    user?: number;
+    agree_terms_of_service_at?: string | null;
+}
 
 /**
- * Terms-of-service screen. Used both as a referenced doc (no acceptance UI)
- * and as a gating step right after SSO login (accept=true). The gating
- * variant adds a sticky red CTA at the bottom.
+ * Faithful port of `lib/pages/terms_and_conditions_page.dart`.
+ *
+ *   AppBar: red ‹ back · centered "이용약관" 18/w700 ED3A3A.
+ *   Body  : 15px outer padding, scrollable card with #F6F6F6 background +
+ *           15px inner padding. Text uses two styles —
+ *             normal: 16/w500 #4A4A4A, line-height 1.6
+ *             bold  : 16/w700 #363636, line-height 1.6
+ *           Sub-items live in a 20px-indent block.
+ *   Footer: centered max-100×50 ED3A3A button "동의 하기" (or "이미 동의하셨습니다."
+ *           text when the user has already agreed). 30px bottom gap.
+ *
+ *   ?accept=true forces the agree CTA to be the only path forward (used as
+ *   a gating step right after SSO login).
  */
 export default function TermsPage() {
     const router = useRouter();
+    const onBack = useSafeBack();
     const search = useSearchParams();
-    const requireAccept = search?.get('accept') === 'true';
-    const [meId, setMeId] = useState<number | null>(null);
+    const forceAccept = search?.get('accept') === 'true';
+    const [me, setMe] = useState<MeProfile | null>(null);
     const [submitting, setSubmitting] = useState(false);
 
     useEffect(() => {
-        if (!requireAccept) return;
         fetchMe()
-            .then((data) => setMeId(data?.id ?? null))
-            .catch((e) => console.warn('fetchMe failed', e));
-    }, [requireAccept]);
+            .then((data: MeProfile) => setMe(data))
+            .catch(() => {});
+    }, []);
+
+    const alreadyAgreed = !!me?.agree_terms_of_service_at;
 
     const onAccept = async () => {
+        if (!me?.user && !me?.id) return;
         if (submitting) return;
         setSubmitting(true);
         try {
-            if (meId != null) {
-                await updateTos(meId);
-            }
-            router.replace('/web_view/Main');
+            await updateTos((me.user ?? me.id) as number);
+            if (forceAccept) router.replace('/web_view/Main');
+            else onBack();
         } catch (e) {
             console.warn('updateTos failed', e);
             if (typeof window !== 'undefined') {
@@ -43,46 +74,166 @@ export default function TermsPage() {
         }
     };
 
-    const ko = tosContent.ko;
-
     return (
         <Screen withTabBar={false}>
-            <AppHeader title="이용약관" />
+            <header className="sticky top-0 z-40 flex h-14 items-center bg-white">
+                {!forceAccept && (
+                    <button
+                        type="button"
+                        onClick={onBack}
+                        aria-label="뒤로"
+                        className="flex h-14 w-14 items-center justify-center text-ara_red"
+                    >
+                        <LeftChevronIcon size={35} />
+                    </button>
+                )}
+                <h1 className="absolute left-0 right-0 mx-auto w-fit text-[18px] font-bold text-ara_red">
+                    이용약관
+                </h1>
+            </header>
 
-            <div
-                className="px-5"
-                style={{ paddingBottom: requireAccept ? '96px' : '24px' }}
-            >
-                <p className="mt-0 text-[13px] text-[#B1B1B1]">{ko.lastUpdated}</p>
-
-                {ko.tos.map((s, i) => (
-                    <section key={i} className="mb-6">
-                        <h2 className="m-0 mb-2 text-[15px] font-bold text-black">{s.title}</h2>
-                        <p className="m-0 whitespace-pre-wrap text-[13px] leading-[1.7] text-[#646464]">
-                            {s.content}
-                        </p>
-                    </section>
-                ))}
+            <div className="px-[15px] pt-[15px] pb-[15px]">
+                <div className="rounded-[2px] bg-[#F6F6F6] p-[15px]">
+                    <Body />
+                </div>
             </div>
 
-            {requireAccept && (
-                <div
-                    className="fixed inset-x-0 z-30 bg-white px-5 pt-3"
-                    style={{
-                        bottom: 0,
-                        paddingBottom: 'calc(12px + var(--ara-safe-bottom))',
-                    }}
-                >
+            <div className="flex h-[80px] items-center justify-center">
+                {alreadyAgreed && !forceAccept ? (
+                    <span className="text-[16px] font-medium text-ara_red">
+                        이미 동의하셨습니다.
+                    </span>
+                ) : (
                     <button
                         type="button"
                         onClick={onAccept}
                         disabled={submitting}
-                        className="block h-[50px] w-full rounded-[10px] bg-ara_red text-[15px] font-bold text-white disabled:bg-ara_red_bright"
+                        className="flex h-[50px] w-[100px] items-center justify-center rounded-[10px] bg-ara_red text-[16px] font-medium text-white disabled:opacity-60"
                     >
-                        {submitting ? '처리 중...' : '동의'}
+                        {submitting ? '처리 중...' : '동의 하기'}
                     </button>
-                </div>
-            )}
+                )}
+            </div>
         </Screen>
+    );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+    return (
+        <p
+            className="m-0 text-[16px] font-medium text-[#4A4A4A]"
+            style={{ lineHeight: 1.6 }}
+        >
+            {children}
+        </p>
+    );
+}
+
+function H({ children }: { children: React.ReactNode }) {
+    return (
+        <p
+            className="m-0 text-[16px] font-bold text-[#363636]"
+            style={{ lineHeight: 1.6 }}
+        >
+            {children}
+        </p>
+    );
+}
+
+function Indent({ children }: { children: React.ReactNode }) {
+    return <div className="pl-[20px]">{children}</div>;
+}
+
+/** Verbatim ToS body — order, line breaks, and indents copied from the
+ *  Flutter `_buildTermsAndConditionsText(Locale('ko'))` branch. */
+function Body() {
+    return (
+        <div className="flex flex-col">
+            <P>new Ara (이하 아라) 이용약관은 현재 적용 중입니다.{'\n'}</P>
+            <H>제 1조. 아라의 목적</H>
+            <Indent>
+                <P>
+                    1. 아라는 KAIST 구성원의 원활한 정보공유를 위해 KAIST 학부 동아리 SPARCS (이하 &quot;SPARCS&quot;)에서 제공하는 공용 게시판 서비스 (Bulletin Board System) 입니다.
+                </P>
+                <P>
+                    2. 1조 1항에서의 KAIST 구성원이란 교수, 교직원, 그리고 재학생과 졸업생, 입주 업체 등을 나타냅니다.{'\n'}
+                </P>
+            </Indent>
+
+            <H>제 2조. 가입 및 탈퇴</H>
+            <Indent>
+                <P>1. 아라는 KAIST 구성원만 이용 가능합니다.</P>
+                <P>2. 아라는 SPARCS SSO를 통해 가입할 수 있습니다.</P>
+                <P>  - SPARCS SSO에서 카이스트 통합인증으로 가입시 별도 승인 없이 바로 서비스 이용이 가능합니다. (교수, 교직원, 재학생, 졸업생 등)</P>
+                <P>  - SPARCS SSO에서 카이스트 통합인증 외 다른 방법으로 가입시 아라 운영진이 승인해야만 서비스 이용이 가능합니다. (입주 업체 등)</P>
+                <P>3. 아라는 회원탈퇴 기능이 없습니다. 다만, 아라 운영진에게 회원 탈퇴를 요청할 수 있습니다.</P>
+                <P>4. 다음의 경우에는 회원자격이 박탈될 수 있습니다.</P>
+                <P>  - 카이스트 구성원이 아닌 것으로 밝혀졌을 경우</P>
+                <P>  - new Ara 이용약관에 명시된 회원의 의무를 지키지 않은 경우</P>
+                <P>  - 아라 이용 중 정보통신망 이용촉진 및 정보보호 등에 관한 법률 및 관계 법령과 본 약관이 금지하거나 공서양속에 반하는 행위를 하는 경우{'\n'}</P>
+            </Indent>
+
+            <H>제 3조. 회원의 의무</H>
+            <Indent>
+                <P>1. 회원은 아라 이용과 관련하여 다음의 행위를 하여서는 안 됩니다.</P>
+                <P>  - SPARCS, 아라 운영진, 또는 특정 개인 및 단체를 사칭하는 행위</P>
+                <P>  - 아라를 이용하여 얻은 정보를 원작자나 아라 운영진의 사전 승낙 없이 복사, 복제, 변경, 번역, 출판, 방송, 기타의 방법으로 사용하거나 이를 타인에게 제공하는 행위</P>
+                <P>  - 다른 회원의 계정을 부정 사용하는 행위</P>
+                <P>  - 타인의 명예를 훼손하거나 모욕하는 행위</P>
+                <P>  - 타인의 지적재산권 등의 권리를 침해하는 행위</P>
+                <P>  - 해킹행위 또는 컴퓨터바이러스의 유포 행위</P>
+                <P>  - 광고성 정보 등 일정한 내용을 지속적으로 전송하는 행위</P>
+                <P>  - 서비스의 안전적인 운영에 지장을 주거나 줄 우려가 있는 일체의 행위</P>
+                <P>  - 범죄행위를 목적으로 하거나 기타 범죄행위와 관련된 행위</P>
+                <P>  - SPARCS의 동의 없이 아라를 영리목적으로 사용하는 행위</P>
+                <P>  - 기타 아라의 커뮤니티 강령에 반하거나 아라 서비스 운영상 부적절하다고 판단하는 행위{'\n'}</P>
+            </Indent>
+
+            <H>제 4조. 게시물에 대한 권리</H>
+            <Indent>
+                <P>1. 회원이 아라 내에 올린 게시물의 저작권은 게시한 회원에게 귀속됩니다.</P>
+                <P>2. 서비스의 게시물 또는 내용물이 위의 약관에 위배될 경우 사전 통지나 동의 없이 삭제될 수 있습니다.</P>
+                <P>3. 제 3조 회원의 의무에 따라, 아라를 이용하여 얻은 정보를 원작자나 아라 운영진의 사전 승낙 없이 복사, 복제, 변경, 번역, 출판, 방송, 기타의 방법으로 사용하거나, 영리목적으로 활용하거나, 이를 타인에게 제공하는 행위는 금지됩니다.{'\n'}</P>
+            </Indent>
+
+            <H>제 5조. 책임의 제한</H>
+            <Indent>
+                <P>1. SPARCS는 다음의 사유로 서비스 제공을 중지하는 것에 대해 책임을 지지 않습니다.</P>
+                <P>  - 설비의 보수 등을 위해 부득이한 경우</P>
+                <P>  - KAIST가 전기통신서비스를 중지하는 경우</P>
+                <P>  - 천재지변, 정전 및 전시 상황인 경우</P>
+                <P>  - 기타 본 서비스를 제공할 수 없는 사유가 발생한 경우</P>
+                <P>2. SPARCS는 다음의 사항에 대해 책임을 지지 않습니다.</P>
+                <P>  - 개재된 회원들의 글에 대한 신뢰도, 정확도</P>
+                <P>  - 아라를 매개로 회원 상호 간 및 회원과 제 3자 간에 발생한 분쟁</P>
+                <P>  - 기타 아라 사용 중 발생한 피해 및 분쟁{'\n'}</P>
+            </Indent>
+
+            <H>제 6조. 문의 및 제보</H>
+            <Indent>
+                <P>1. 아라에 대한 건의사항 또는 버그에 대한 사항은 구글폼을 통해 문의 및 제보할 수 있습니다.</P>
+                <button
+                    type="button"
+                    onClick={() => openExternal('https://sparcs.page.link/newara-feedback')}
+                    className="m-0 bg-transparent text-left text-[16px] font-medium text-blue-600 underline"
+                    style={{ lineHeight: 1.6 }}
+                >
+                    https://sparcs.page.link/newara-feedback
+                </button>
+                <P>2. 6조 1항의 구글폼이 작동하지 않거나, 기타 사항의 경우 new-ara@sparcs.org 를 통해 문의 및 제보할 수 있습니다.{'\n'}</P>
+            </Indent>
+
+            <H>제 7조. 게시, 개정 및 해석</H>
+            <Indent>
+                <P>1. 아라 운영진은 본 약관에 대해 아라 회원가입시 회원의 동의를 받습니다.</P>
+                <P>2. 아라 운영진은 약관의규제에관한법률, 정보통신망이용촉진및정보보호등에관한법률 등 관련법을 위배하지 않는 범위에서 본 약관을 개정할 수 있습니다.</P>
+                <P>3. 본 약관을 개정하는 경우 적용일자, 개정 내용 및 사유를 명시하여 개정 약관의 적용일자 7일 전부터 적용일자 전일까지 아라의 &lsquo;뉴아라 공지&rsquo; 게시판을 통해 공지합니다.</P>
+                <P>4. 회원은 개정약관이 공지된 지 7일 내에 개정약관에 대한 거부의 의사표시를 할 수 있습니다. 이 경우 회원은 아라 운영진에게 메일을 발송하여 즉시 사용 중인 모든 지원 서비스를 해지하고 본 서비스에서 회원 탈퇴할 수 있습니다.</P>
+                <P>5. 아라 운영진은 개정약관이 공지된 지 7일 내에 거부의 의사표시를 하지 않은 회원에 대해 개정약관에 대해 동의한 것으로 간주합니다.</P>
+                <P>6. 본 약관의 해석은 아라 운영진이 담당하며, 분쟁이 있을 경우 민법 등 관계 법률과 관례에 따릅니다.{'\n'}</P>
+            </Indent>
+
+            <P>본 약관은 2020-09-26부터 적용됩니다.</P>
+        </div>
     );
 }

--- a/src/app/web_view/User/[id]/page.tsx
+++ b/src/app/web_view/User/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
     PostPreview,
     Screen,
 } from '@/app/web_view/_components';
+import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import { blockUser } from '@/lib/api/user';
 import { fetchUserProfile, fetchUserPosts } from '@/lib/api/user_profile';
 import type { ResponsePost } from '@/lib/types/post';
@@ -28,6 +29,7 @@ interface UserProfile {
  */
 export default function UserViewPage() {
     const router = useRouter();
+    const onBack = useSafeBack();
     const params = useParams();
     const idParam = params?.id;
     const userId =
@@ -85,7 +87,7 @@ export default function UserViewPage() {
         try {
             await blockUser(userId);
             if (typeof window !== 'undefined') window.alert('차단했어요.');
-            router.back();
+            onBack();
         } catch (e) {
             console.warn('blockUser failed', e);
             if (typeof window !== 'undefined') window.alert('차단에 실패했어요.');

--- a/src/app/web_view/_components/AppHeader.tsx
+++ b/src/app/web_view/_components/AppHeader.tsx
@@ -42,7 +42,13 @@ export function AppHeader({
 
     const handleBack = () => {
         if (onBack) return onBack();
-        if (typeof window !== 'undefined' && window.history.length > 1) router.back();
+        if (typeof window !== 'undefined' && window.history.length > 1) {
+            router.back();
+            return;
+        }
+        // Deep-link entry — no SPA history to pop. Send the user to Main so
+        // the back arrow never feels dead and never falls out of /web_view.
+        router.replace('/web_view/Main');
     };
 
     const showDefaultLeading = leading === undefined;

--- a/src/app/web_view/_components/ContentArea.tsx
+++ b/src/app/web_view/_components/ContentArea.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { MouseEvent, ReactNode } from 'react';
+import { bridge } from '@/app/web_view/_bridge';
+
+interface ContentAreaProps {
+    children: ReactNode;
+    className?: string;
+}
+
+const SAME_ORIGIN_PREFIX = '/web_view/';
+
+/**
+ * Wraps user-generated content (post bodies, comments, notification rows)
+ * and intercepts native anchor clicks so the WebView never navigates off
+ * the SPA scope.
+ *
+ *   mailto: / tel: / sms:    → let the browser handle it (native pickers).
+ *   /web_view/*              → routed through Next.js client navigation.
+ *   anything else            → forwarded to the native shell via the
+ *                              `openExternal` bridge command, with a
+ *                              `window.open` fallback when the bridge is
+ *                              unavailable (browser preview, dev).
+ *
+ * Without this guard, a TipTap-rendered <a href="https://…"> would replace
+ * the entire WebView document on click, falling out of /web_view/* — that
+ * showed up as the desktop main page leaking through.
+ */
+export function ContentArea({ children, className }: ContentAreaProps) {
+    const router = useRouter();
+
+    const onClick = (e: MouseEvent<HTMLDivElement>) => {
+        const target = e.target as HTMLElement | null;
+        if (!target) return;
+        const anchor = target.closest('a') as HTMLAnchorElement | null;
+        if (!anchor) return;
+        const rawHref = anchor.getAttribute('href');
+        if (!rawHref) return;
+
+        // Plain in-page anchors and protocol handlers — let the browser run.
+        if (
+            rawHref.startsWith('#') ||
+            rawHref.startsWith('mailto:') ||
+            rawHref.startsWith('tel:') ||
+            rawHref.startsWith('sms:')
+        ) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (rawHref.startsWith(SAME_ORIGIN_PREFIX)) {
+            router.push(rawHref);
+            return;
+        }
+
+        // Resolve relative URLs against the page so the bridge always gets
+        // an absolute string.
+        let absolute = rawHref;
+        try {
+            absolute = new URL(rawHref, window.location.href).toString();
+            if (absolute.startsWith(window.location.origin + SAME_ORIGIN_PREFIX)) {
+                router.push(absolute.slice(window.location.origin.length));
+                return;
+            }
+        } catch {
+            /* leave rawHref as-is and try the bridge with whatever we have */
+        }
+
+        try {
+            bridge?.send('openExternal', { url: absolute });
+            return;
+        } catch {
+            /* fall through to window.open */
+        }
+        window.open(absolute, '_blank', 'noopener,noreferrer');
+    };
+
+    return (
+        <div className={className} onClick={onClick}>
+            {children}
+        </div>
+    );
+}

--- a/src/app/web_view/_components/icons.tsx
+++ b/src/app/web_view/_components/icons.tsx
@@ -182,6 +182,9 @@ export function VerifiedIcon(p: IconProps) {
 export function LanguageIcon(p: IconProps) {
     return <MaskIcon src={`${ICON_BASE}/language.svg`} fallback={24} {...p} />;
 }
+export function CameraIcon(p: IconProps) {
+    return <MaskIcon src={`${ICON_BASE}/camera.svg`} fallback={24} {...p} />;
+}
 
 /* =========================================================================
  * Post-preview badges + meatballs menu.

--- a/src/app/web_view/_components/index.ts
+++ b/src/app/web_view/_components/index.ts
@@ -1,5 +1,6 @@
 export { AppHeader } from './AppHeader';
 export { BottomTabBar, isTabRoot } from './BottomTabBar';
+export { ContentArea } from './ContentArea';
 export { Screen } from './Screen';
 export { StickyComposer, ComposerSpacer } from './StickyComposer';
 export { PostPreview } from './PostPreview';

--- a/src/app/web_view/hooks/useSafeBack.ts
+++ b/src/app/web_view/hooks/useSafeBack.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+/**
+ * `router.back()` is a no-op when the WebView was opened to a deep link
+ * (no SPA history to pop) — it leaves the user looking at a back arrow
+ * that does nothing. Mirror Flutter's `Navigator.canPop()` fallback by
+ * sending them to `/web_view/Main` instead.
+ */
+export function useSafeBack() {
+    const router = useRouter();
+    return useCallback(() => {
+        if (typeof window !== 'undefined' && window.history.length > 1) {
+            router.back();
+            return;
+        }
+        router.replace('/web_view/Main');
+    }, [router]);
+}

--- a/src/app/web_view/not-found.tsx
+++ b/src/app/web_view/not-found.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Screen } from '@/app/web_view/_components';
+
+/**
+ * Catches unmatched routes under /web_view/* so the WebView never falls
+ * through to the desktop-web `app/not-found.tsx` (which paints a 800×450
+ * marketing 404 image meant for the laptop site).
+ *
+ * We send the user back to /web_view/Main on the next tick — the splash is
+ * just there to avoid a blank flash if the navigation is slow.
+ */
+export default function WebViewNotFound() {
+    const router = useRouter();
+    useEffect(() => {
+        const t = setTimeout(() => router.replace('/web_view/Main'), 0);
+        return () => clearTimeout(t);
+    }, [router]);
+    return (
+        <Screen withTabBar={false}>
+            <div className="flex min-h-[100dvh] items-center justify-center text-[14px] text-[#B1B1B1]">
+                이동 중...
+            </div>
+        </Screen>
+    );
+}


### PR DESCRIPTION
…nquiry·Terms 재포팅

- /web_view 스코프 밖으로 새는 link/router.push 추적해 모두 /web_view/* 로 정정
- 딥링크 진입 시 history 가 비어 있으면 router.back() 이 무동작이라 빈 화면에 머물던 현상 해결 (useSafeBack 훅 도입 후 Main 으로 폴백)
- /web_view/* 미매칭 라우트가 데스크톱 404 → 메인 페이지로 떨어지던 폴백 차단 (web_view/not-found.tsx 추가)
- TipTap 본문/첨부 파일 앵커가 WebView 문서를 통째 교체하던 누수 차단 (ContentArea + bridge.openExternal)
- HomeAppBar 의 지구본 버튼 제거
- Login: hardcoded next URL 제거 (window.location.origin 사용)
- Settings/Edit/Inquiry/Terms/BlockedUsers : Flutter setting/profile_edit/ inquiry/terms_and_conditions/BlockedUserDialog 와 1:1 픽셀 매칭으로 재포팅