### PR TITLE
feat(keyboard-inset): bottom-anchored scrolling with messenger-style …

### DIFF
--- a/packages/keyboard-inset/CHANGELOG.md
+++ b/packages/keyboard-inset/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.2.0
+
+- Core: `createBottomAnchor(target, opts)` — bottom-anchored scrolling across
+  keyboard-driven height changes, for an `HTMLElement` or the `window` scroller
+  - two pin modes: `'at-bottom'` (re-glue only when the user was already at the
+    bottom — feed style) and `'always'` (preserve the bottom edge wherever the
+    user is — messenger-style fold)
+  - element target compensates on `ResizeObserver`; window target compensates
+    synchronously on `resize` so per-frame IME-animation resizes track
+    frame-by-frame
+  - window safety model: focus-gated shrink compensation, debt-bounded grow
+    compensation, direction-dependent gap baseline (fresh-read shrink; grow
+    fresh unless clamp-pinned at the bottom), overlay carry ledger, `effectiveHeight` = layout height −
+    overlay inset, orientation reset — browser-chrome (URL bar) noise can't
+    drift the page
+- React: `pin` / `startAtBottom` options on `useBottomAnchoredScroll`; new
+  `useWindowBottomAnchoredScroll` for pages that scroll the document
+
 ## 0.1.0 (unreleased)
 
 Initial version, extracted from the new-ara webview shell.

--- a/packages/keyboard-inset/README.md
+++ b/packages/keyboard-inset/README.md
@@ -84,6 +84,83 @@ Size a chat screen that shrinks above the keyboard (pan-invariant, unlike `100dv
 }
 ```
 
+## Bottom-anchored scrolling
+
+Pinning content to the bottom edge while the keyboard resizes the viewport is a
+second problem the inset alone doesn't solve. `createBottomAnchor` compensates
+the scroll position so the bottom stays put across height changes, on either an
+inner scroll container or the document scroller:
+
+```ts
+import { createBottomAnchor } from '@sparcs-kaist/keyboard-inset';
+
+const detach = createBottomAnchor(listEl, { pin: 'always' });   // inner chat column
+const detach = createBottomAnchor(window, { pin: 'always' });   // page with a fixed composer
+```
+
+Two pin modes, because the right UX differs per surface — choosing between them
+is the point of the API:
+
+| `pin` | When the keyboard opens | Fits |
+|---|---|---|
+| `'at-bottom'` (default) | re-glue to the bottom edge **only if the user was already there**; a user who scrolled up keeps their reading position | forum / feed, timelines, comment lists read top-down |
+| `'always'` | preserve whatever sits at the bottom edge **wherever the user is** — the viewport folds up against the keyboard | messenger surfaces: KakaoTalk, Instagram DM, Slack |
+
+**Element target** compensates on `ResizeObserver` ticks — the container box is
+the signal, so content growth (new messages) never fires it. Because scroll
+steps run before the observer within a frame, only a scroll bearing the engine
+clamp's signature — a grow in flight landing exactly at the new bottom — is
+swallowed (it must not re-baseline the stored gap the tick is about to read);
+every other scroll, including a user drag mid-animation, re-baselines the gap
+live. A width change re-glues a user who was at the
+bottom in **either** mode — being at the bottom is reflow-invariant.
+`startAtBottom` (default true) scrolls to the bottom on attach, which is what a
+chat column wants on mount.
+
+**Window target** compensates on `resize` synchronously, so on hosts that
+resize the layout viewport per-frame with the IME animation (the NewAra Flutter
+shell, an `adjustResize` WebView) the content tracks the keyboard frame-by-frame
+instead of being swallowed and jumping at the end. Because it moves the whole
+page, it is hardened against browser-chrome noise:
+
+- **Focus gate** — a shrink engages compensation only when an editable owns
+  focus, the tracker latched a keyboard, or a compensated presentation is
+  already open (focus can race the closing frames). A collapsing URL bar never
+  moves the page.
+- **Debt-bounded grow compensation** — grow (fold-out) is capped at the
+  *nominal* shrink debt (px admitted through the focus gate), drained by the
+  grow delta itself rather than by achieved scroll movement, so a fold-out that
+  clamps at the top can't strand debt and chrome *growth* can't drift the page
+  past where it started.
+- **Direction-dependent gap baseline** — a shrink (fold-in) is never
+  engine-clamped, so its gap is read *fresh* against the pre-event height; a
+  post body that loads silently after mount (no scroll or resize event) thus
+  can't corrupt the fold. A grow (fold-out) also prefers the *fresh* gap and
+  falls back to the *stored* gap only when the geometry bears the engine
+  clamp's signature (`scrollY` pinned at the document bottom): a silent grow
+  under an open keyboard moves the bottom away from the user and so can never
+  fake the signature, keeping a post that grew mid-fold (placeholder→data swap,
+  composer auto-grow) from jumping the page on dismissal.
+- **Overlay carry ledger** — a fold-in that clamps at the physical document
+  edge (overlay hosts can't scroll past the end) records the un-foldable
+  shortfall and fold-out repays it, so the page returns to the user's true gap
+  instead of drifting up by the keyboard height. Window writes force instant
+  scroll (overriding a consumer's `scroll-behavior: smooth`) so the shortfall
+  readback taken right after a write measures real geometry, not a
+  mid-animation phantom.
+- **`effectiveHeight` = layout height − overlay inset** — resize-mode hosts move
+  the layout term, overlay hosts (plain iOS Safari) move the inset; one delta
+  stream covers both.
+- **Orientation reset** — a width change makes heights incomparable, so the
+  outstanding debt and carry are dropped and geometry restarts from the new size.
+- `startAtBottom` is **element-only** — the window target must never move the
+  page on attach.
+
+```ts
+const detach = createBottomAnchor(window, { pin: 'at-bottom', slack: 40 });
+detach();
+```
+
 ## React
 
 ```tsx
@@ -106,6 +183,23 @@ function MessageList() {
   // users who scrolled up keep their reading position.
   useBottomAnchoredScroll(ref);
   return <div ref={ref} className="overflow-y-auto" />;
+}
+```
+
+`useBottomAnchoredScroll` takes the same `pin` option — pass `pin: 'always'`
+for a messenger column, leave it at `'at-bottom'` for a feed. For pages that
+scroll the window rather than an inner column (a post with a fixed comment
+composer), use `useWindowBottomAnchoredScroll`, which defaults to `'always'`
+and never moves the page on mount:
+
+```tsx
+import { useWindowBottomAnchoredScroll } from '@sparcs-kaist/keyboard-inset/react';
+
+function PostPage() {
+  // folds the article up against the keyboard when the composer focuses;
+  // keyboard-gated, so browser-chrome resizes can't drift it
+  useWindowBottomAnchoredScroll();
+  return <article>…</article>;
 }
 ```
 
@@ -140,10 +234,12 @@ See the TypeScript declarations for full docs. Summary:
 - `createKeyboardTracker(options?)` → `KeyboardTracker` — `getState()`, `subscribe(cb)`, `setOverride(px|null)`, `destroy()`
 - `getSharedKeyboardTracker()` — lazy shared instance (used by the React hooks); HMR-safe
 - `publishKeyboardCssVars(tracker, { target?, prefix? })` → unsubscribe
+- `createBottomAnchor(target, { pin?, slack?, startAtBottom?, tracker? })` → detach — bottom-pins an `HTMLElement` or `window` across keyboard resizes
 - `isEditableElement(el)` — the focus heuristic used internally
 - `KeyboardState` — `{ visible, insetPx, mode: 'resize'|'overlay'|'unknown', visualHeight, editableFocused, source }`
+- `ScrollPinMode` — `'at-bottom' | 'always'`
 - Options: `minKeyboardHeight` (50), `residualEpsilon` (32), `iosDismissFix` (true)
-- React: `useKeyboard(tracker?)`, `useKeyboardCssVars(opts?)`, `useBottomAnchoredScroll(ref, { slack? })`
+- React: `useKeyboard(tracker?)`, `useKeyboardCssVars(opts?)`, `useBottomAnchoredScroll(ref, { pin?, slack?, startAtBottom? })`, `useWindowBottomAnchoredScroll({ pin?, slack? })`
 
 ## Known limits
 

--- a/packages/keyboard-inset/package.json
+++ b/packages/keyboard-inset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sparcs-kaist/keyboard-inset",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Framework-agnostic soft-keyboard inset tracking for mobile web apps and WebViews — Android adjustResize, iOS visualViewport quirks, Chrome interactive-widget — with React bindings.",
     "license": "MIT",
     "repository": {

--- a/packages/keyboard-inset/src/index.ts
+++ b/packages/keyboard-inset/src/index.ts
@@ -12,3 +12,5 @@ export type {
 } from './tracker';
 export { publishKeyboardCssVars } from './css-vars';
 export type { PublishCssVarsOptions } from './css-vars';
+export { createBottomAnchor } from './scroll-anchor';
+export type { BottomAnchorOptions, ScrollPinMode } from './scroll-anchor';

--- a/packages/keyboard-inset/src/react.ts
+++ b/packages/keyboard-inset/src/react.ts
@@ -8,6 +8,7 @@ import {
     type KeyboardTracker,
 } from './tracker';
 import { publishKeyboardCssVars, type PublishCssVarsOptions } from './css-vars';
+import { createBottomAnchor, type ScrollPinMode } from './scroll-anchor';
 
 // useSyncExternalStore requires a REFERENTIALLY STABLE server snapshot —
 // returning a fresh object per call triggers React's "getServerSnapshot
@@ -48,50 +49,60 @@ export function useKeyboardCssVars(opts?: PublishCssVarsOptions): void {
 
 export interface BottomAnchoredScrollOptions {
     /**
-     * How close (px) to the bottom edge still counts as "at the bottom".
-     * Default 40.
+     * `'at-bottom'` (default): re-glue to the bottom edge only when the user
+     * was already there. `'always'`: preserve the bottom-edge content
+     * wherever the user is — messenger-style folding against the keyboard.
+     */
+    pin?: ScrollPinMode;
+    /**
+     * How close (px) to the bottom edge still counts as "at the bottom"
+     * (`'at-bottom'` mode). Default 40.
      */
     slack?: number;
+    /** Scroll to the bottom when anchoring starts. Default true. */
+    startAtBottom?: boolean;
 }
 
 /**
- * Keep a scroll container glued to its bottom edge across CONTAINER
- * resizes (e.g. the keyboard shrinking a chat list); a user who scrolled
- * up keeps their reading position. The at-bottom flag comes from the
- * container's own scroll events — post-resize geometry can't tell where
- * the user was. Content growth is out of scope (it doesn't change the
- * container box): keep scrolling on data changes yourself.
+ * Keep a scroll container's bottom edge anchored across CONTAINER resizes
+ * (e.g. the keyboard shrinking a chat list) — see `pin` for the two UX
+ * modes. Content growth is out of scope (it doesn't change the container
+ * box): keep scrolling on data changes yourself.
  */
 export function useBottomAnchoredScroll<T extends HTMLElement>(
     ref: RefObject<T | null>,
     opts: BottomAnchoredScrollOptions = {},
 ): void {
-    const slack = opts.slack ?? 40;
+    const { pin = 'at-bottom', slack = 40, startAtBottom = true } = opts;
     useEffect(() => {
         const el = ref.current;
-        if (!el || typeof ResizeObserver === 'undefined') return;
+        if (!el) return;
+        return createBottomAnchor(el, { pin, slack, startAtBottom });
+    }, [ref, pin, slack, startAtBottom]);
+}
 
-        // Starts true: the initial observe-fire doubles as the initial
-        // scroll-to-bottom, which is what a chat screen wants on mount.
-        let atBottom = true;
+export interface WindowBottomAnchoredScrollOptions {
+    /**
+     * Default `'always'` — the reason to mount this hook is the
+     * messenger-style fold; pass `'at-bottom'` for feed-style surfaces.
+     */
+    pin?: ScrollPinMode;
+    /** See {@link BottomAnchoredScrollOptions.slack}. */
+    slack?: number;
+}
 
-        const onScroll = () => {
-            atBottom = el.scrollHeight - el.clientHeight - el.scrollTop <= slack;
-        };
-        el.addEventListener('scroll', onScroll, { passive: true });
-
-        const ro = new ResizeObserver(() => {
-            if (!atBottom) return;
-            el.scrollTop = el.scrollHeight - el.clientHeight;
-            atBottom = true; // the write above re-fires onScroll, but be explicit
-        });
-        ro.observe(el);
-
-        return () => {
-            ro.disconnect();
-            el.removeEventListener('scroll', onScroll);
-        };
-    }, [ref, slack]);
+/**
+ * Bottom-anchor the DOCUMENT scroller across keyboard presentations, for
+ * pages that scroll the window rather than an inner column (a post with a
+ * fixed comment composer). Never moves the page on mount; shrink
+ * compensation is keyboard-gated so browser chrome noise can't drift it.
+ */
+export function useWindowBottomAnchoredScroll(
+    opts: WindowBottomAnchoredScrollOptions = {},
+): void {
+    const { pin = 'always', slack = 40 } = opts;
+    useEffect(() => createBottomAnchor(window, { pin, slack }), [pin, slack]);
 }
 
 export type { KeyboardState, KeyboardTracker, KeyboardViewportMode, KeyboardTrackerOptions } from './tracker';
+export type { ScrollPinMode, BottomAnchorOptions } from './scroll-anchor';

--- a/packages/keyboard-inset/src/scroll-anchor.ts
+++ b/packages/keyboard-inset/src/scroll-anchor.ts
@@ -1,0 +1,277 @@
+/**
+ * Bottom-anchored scrolling across keyboard-driven height changes.
+ *
+ * Two pin modes, because the right UX differs per surface:
+ *
+ *   'at-bottom' — re-glue to the bottom edge only when the user was already
+ *                 there; a user who scrolled up keeps their reading position
+ *                 (forum / feed style).
+ *   'always'    — preserve whatever content sits at the bottom edge, wherever
+ *                 the user is: the viewport "folds" against the keyboard the
+ *                 way messenger apps do (KakaoTalk, Instagram DM, Slack).
+ *
+ * All compensation is written as an ABSOLUTE target derived from a bottom
+ * gap (content px hidden below the visible bottom edge), never as a relative
+ * delta: when a viewport grows back, engines clamp the scroll offset during
+ * layout BEFORE any callback runs, and a relative adjustment on top of that
+ * clamp double-compensates. Absolute writes are idempotent against the clamp.
+ *
+ * Where the baseline gap comes from is direction-dependent:
+ *   - A SHRINK is never engine-clamped (the scrollable max only grows), so
+ *     the baseline is read fresh against the pre-event height. This also
+ *     survives content growth that fired no scroll event (a post body
+ *     loading after mount) — a stored gap would be stale.
+ *   - A GROW may already be engine-clamped by the time we run, so the
+ *     baseline is the STORED gap, maintained by scroll events. On elements,
+ *     scroll steps run before ResizeObserver delivery within a frame, so a
+ *     scroll bearing the clamp's signature — a grow in flight and a landing
+ *     exactly at the new bottom — must not overwrite the stored baseline;
+ *     every other scroll is the user and re-baselines live. The window
+ *     resize event runs before scroll steps, so the window path needs no
+ *     such guard.
+ *
+ * Element targets compensate on ResizeObserver ticks (the container box is
+ * the signal — content growth never fires it). The window target compensates
+ * on `resize` synchronously, so on hosts that resize the layout viewport
+ * per-frame with the IME animation the content tracks the keyboard
+ * frame-by-frame instead of being swallowed and jumping at the end. Window
+ * shrink compensation is gated on an editable owning focus (or a visible
+ * tracker state) and grow compensation is bounded by NOMINAL debt — the
+ * shrink px previously admitted through the gate — so URL-bar chrome noise
+ * in plain browsers can never drift the scroll position. Overlay hosts add
+ * one more ledger: a fold-in clamped at the physical document edge records
+ * the shortfall as `carry`, and fold-out subtracts it, so the page returns
+ * to the user's true gap instead of drifting up by the un-foldable px.
+ */
+
+import { getSharedKeyboardTracker, isEditableElement, type KeyboardTracker } from './tracker';
+
+export type ScrollPinMode = 'at-bottom' | 'always';
+
+export interface BottomAnchorOptions {
+    /** How to anchor. Default `'at-bottom'`. */
+    pin?: ScrollPinMode;
+    /**
+     * `'at-bottom'` only: px from the bottom edge that still counts as
+     * "at the bottom". Default 40.
+     */
+    slack?: number;
+    /**
+     * Element targets only: scroll to the bottom when anchoring starts
+     * (what a chat column wants on mount). Default true. Ignored for the
+     * window target, which must never move on attach.
+     */
+    startAtBottom?: boolean;
+    /**
+     * Window target only: keyboard tracker consulted for overlay-mode
+     * occlusion and visibility. Default: the shared tracker.
+     */
+    tracker?: KeyboardTracker;
+}
+
+/**
+ * Keep `target`'s bottom edge anchored across height changes (see module
+ * doc for the mode semantics). Returns a detach function.
+ */
+export function createBottomAnchor(
+    target: HTMLElement | Window,
+    opts: BottomAnchorOptions = {},
+): () => void {
+    if (typeof window === 'undefined') return () => {};
+    const pin = opts.pin ?? 'at-bottom';
+    const slack = opts.slack ?? 40;
+    if (target instanceof HTMLElement) {
+        return anchorElement(target, pin, slack, opts.startAtBottom ?? true);
+    }
+    return anchorWindow(pin, slack, opts.tracker ?? getSharedKeyboardTracker());
+}
+
+function anchorElement(
+    el: HTMLElement,
+    pin: ScrollPinMode,
+    slack: number,
+    startAtBottom: boolean,
+): () => void {
+    if (typeof ResizeObserver === 'undefined') return () => {};
+
+    const readGap = () => el.scrollHeight - el.clientHeight - el.scrollTop;
+    const writeGap = (gap: number) => {
+        el.scrollTop = el.scrollHeight - el.clientHeight - gap;
+    };
+
+    // Seeded from geometry, not assumed: a consumer mounting at the top
+    // with startAtBottom:false must not count as "at the bottom".
+    let gap = readGap();
+    let first = true;
+    let lastHeight = 0;
+    let lastWidth = 0;
+
+    const onScroll = () => {
+        // Scroll steps run before ResizeObserver delivery: while a GROW is
+        // in flight, a scroll landing exactly at the new bottom is the
+        // engine's own clamp — it must not overwrite the pre-event baseline
+        // the observer tick is about to need. Anything else (any position
+        // above the bottom, or any scroll during a shrink) is the user;
+        // ignoring those would make grow ticks fight a live drag.
+        if (el.clientHeight > lastHeight && readGap() < 1) return;
+        gap = readGap();
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+
+    const ro = new ResizeObserver(() => {
+        const height = el.clientHeight;
+        const width = el.clientWidth;
+        const heightChanged = height !== lastHeight;
+        const widthChanged = !first && width !== lastWidth;
+        const shrunk = heightChanged && !first && height < lastHeight;
+        // Shrink: fresh against the pre-event height (see module doc).
+        // Grow: the stored gap is the only uncorrupted pre-event truth.
+        const baseline = shrunk
+            ? el.scrollHeight - lastHeight - el.scrollTop
+            : gap;
+        const wasFirst = first;
+        first = false;
+        lastHeight = height;
+        lastWidth = width;
+        if (wasFirst) {
+            if (startAtBottom) writeGap(0);
+        } else if (widthChanged) {
+            // Reflow: the old gap is not comparable in either mode. Being
+            // at the bottom IS reflow-invariant — keep a glued user glued.
+            if (baseline <= slack) writeGap(0);
+        } else if (heightChanged) {
+            if (pin === 'always') {
+                writeGap(baseline);
+            } else if (baseline <= slack) {
+                writeGap(0);
+            }
+        }
+        gap = readGap();
+    });
+    ro.observe(el);
+
+    return () => {
+        ro.disconnect();
+        el.removeEventListener('scroll', onScroll);
+    };
+}
+
+function anchorWindow(
+    pin: ScrollPinMode,
+    slack: number,
+    tracker: KeyboardTracker,
+): () => void {
+    const doc = document.documentElement;
+    // Height of the document viewport actually above the keyboard: layout
+    // height minus overlay occlusion. Resize-mode hosts move the first term,
+    // overlay hosts the second — one delta stream covers both.
+    const effectiveHeight = () => doc.clientHeight - tracker.getState().insetPx;
+    // Content px below the visible bottom edge.
+    const readGap = () => doc.scrollHeight - window.scrollY - effectiveHeight();
+    const writeGap = (gap: number) => {
+        const max = Math.max(0, doc.scrollHeight - doc.clientHeight);
+        const y = doc.scrollHeight - effectiveHeight() - gap;
+        // Force an instant scroll: under `scroll-behavior: smooth` the
+        // write would animate asynchronously and the carry readback right
+        // after it would measure a phantom shortfall. (CSS `auto` means
+        // instant; the ScrollOptions 'auto' keyword would defer to CSS.)
+        const scroller = (document.scrollingElement ?? doc) as HTMLElement;
+        const prev = scroller.style.scrollBehavior;
+        scroller.style.scrollBehavior = 'auto';
+        window.scrollTo(window.scrollX, Math.min(max, Math.max(0, y)));
+        scroller.style.scrollBehavior = prev;
+    };
+
+    let lastHeight = effectiveHeight();
+    let lastWidth = window.innerWidth;
+    let gap = readGap();
+    // NOMINAL px of gate-admitted shrink not yet grown back. Drained by the
+    // grow delta itself, never by achieved scroll movement — a fold-out that
+    // clamps at the top must not strand debt that holds the gate open.
+    let debt = 0;
+    // Fold px that clamped at the physical document edge (overlay hosts
+    // cannot scroll past the end). Still owed back on fold-out, or the page
+    // ends up drifted upward by the un-foldable amount.
+    let carry = 0;
+
+    const onScroll = () => {
+        gap = readGap();
+    };
+
+    const evaluate = () => {
+        const width = window.innerWidth;
+        const height = effectiveHeight();
+        const delta = lastHeight - height; // >0 = shrink toward the keyboard
+        const prevHeight = lastHeight;
+        lastHeight = height;
+        if (width !== lastWidth) {
+            // Orientation change: geometry incomparable, drop the ledgers.
+            lastWidth = width;
+            debt = 0;
+            carry = 0;
+            gap = readGap();
+            return;
+        }
+        if (delta === 0) return;
+        if (delta > 0) {
+            // Shrink baseline read fresh (never engine-clamped; survives
+            // content growth that fired no scroll event). userGap is what
+            // the user perceives: the raw gap minus any fold already stuck
+            // at the document edge.
+            const userGap = doc.scrollHeight - window.scrollY - prevHeight - carry;
+            // Only a keyboard-plausible shrink engages: an editable owns
+            // focus, the tracker latched a keyboard, or we're inside a
+            // compensated presentation (focus can race the last frames).
+            const keyboardish = isEditableElement(document.activeElement)
+                || tracker.getState().visible
+                || debt > 0;
+            if (keyboardish && (pin === 'always' || userGap <= slack)) {
+                writeGap(userGap);
+                debt += delta;
+                carry = Math.max(0, readGap() - userGap);
+            }
+        } else if (debt > 0) {
+            const growth = -delta;
+            const undo = Math.min(growth, debt);
+            debt -= undo;
+            if (pin === 'always') {
+                // Prefer a fresh baseline here too (the stored gap goes
+                // stale when the document grows silently under an open
+                // keyboard — a post body resolving, a composer growing) —
+                // UNLESS the geometry bears the engine clamp's signature,
+                // scrollY pinned at the document bottom, where the fresh
+                // read is post-clamp and the stored gap is the only
+                // pre-event truth. A silent grow moves the bottom away
+                // from the user, so it can never fake the signature.
+                const maxScroll = Math.max(0, doc.scrollHeight - doc.clientHeight);
+                const clamped = window.scrollY >= maxScroll - 1;
+                const baseline = clamped
+                    ? gap
+                    : doc.scrollHeight - window.scrollY - prevHeight;
+                // Fold out to the user's perceived gap; growth beyond the
+                // debt leaves the page where it is.
+                const userGap = baseline - carry;
+                const target = userGap - (growth - undo);
+                writeGap(target);
+                carry = Math.max(0, readGap() - target);
+            }
+            if (debt === 0) carry = 0;
+        }
+        gap = readGap();
+    };
+
+    // Synchronous on purpose: resize-mode hosts fire per animation frame,
+    // and compensating inside the event keeps the pin paint-atomic.
+    window.addEventListener('resize', evaluate);
+    window.visualViewport?.addEventListener('resize', evaluate);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    const unsubscribe = tracker.subscribe(evaluate); // overlay-mode inset changes
+    gap = readGap();
+
+    return () => {
+        unsubscribe();
+        window.removeEventListener('resize', evaluate);
+        window.visualViewport?.removeEventListener('resize', evaluate);
+        window.removeEventListener('scroll', onScroll);
+    };
+}

--- a/packages/keyboard-inset/test/scroll-anchor.test.ts
+++ b/packages/keyboard-inset/test/scroll-anchor.test.ts
@@ -1,0 +1,870 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBottomAnchor } from '../src/scroll-anchor';
+import { INITIAL_KEYBOARD_STATE, type KeyboardState, type KeyboardTracker } from '../src/tracker';
+
+/**
+ * Harness: jsdom does no layout, so every geometry the module reads
+ * (client/scroll box, scrollTop/scrollY) is a hand-built fake that behaves
+ * like a real browser in the three ways the code relies on:
+ *
+ *   1. a scroll WRITE clamps to the scrollable range and, if it moved,
+ *      dispatches 'scroll';
+ *   2. shrinking/growing a clientHeight (or scrollHeight) RE-CLAMPS the
+ *      stored offset into the new [0, scrollHeight - clientHeight] range and,
+ *      if it moved, dispatches 'scroll' — real engines clamp the scroll
+ *      offset during layout BEFORE the ResizeObserver/resize callback runs.
+ *      This clamp is applied EAGERLY inside `setClientHeight`/`setScrollHeight`
+ *      (i.e. before the following `.fire()`/`.resize()`), matching real event
+ *      order. The absolute gap-preserving writes in the module are only
+ *      idempotent against this clamp — the old harness lacked it and so
+ *      silently passed over two double-compensation bugs.
+ *   3. `setClientHeight(v, { deferClamp: true })` + `flushClamp()` lets a test
+ *      reorder the clamp AFTER the RO tick, to prove the absolute write is
+ *      correct in both event orders.
+ *
+ * ResizeObserver is mocked so element ticks fire on command; the keyboard
+ * tracker is injected so overlay-mode inset changes fire on command too.
+ */
+
+// ---- ResizeObserver mock -------------------------------------------------
+
+class MockResizeObserver {
+    cb: ResizeObserverCallback;
+    observed: Element[] = [];
+    disconnected = false;
+    constructor(cb: ResizeObserverCallback) {
+        this.cb = cb;
+        roInstances.push(this);
+    }
+    observe(el: Element): void {
+        this.observed.push(el);
+    }
+    unobserve(): void {}
+    disconnect(): void {
+        this.disconnected = true;
+        this.observed = [];
+    }
+    fire(): void {
+        this.cb([], this as unknown as ResizeObserver);
+    }
+}
+
+let roInstances: MockResizeObserver[];
+
+function lastRO(): MockResizeObserver {
+    return roInstances[roInstances.length - 1];
+}
+
+// ---- scrollable element fake --------------------------------------------
+
+interface ClampOpts {
+    /** Skip the layout re-clamp so a test can order it after the RO tick. */
+    deferClamp?: boolean;
+}
+
+interface ScrollableEl extends HTMLDivElement {
+    setClientHeight(v: number, opts?: ClampOpts): void;
+    setClientWidth(v: number): void;
+    setScrollHeight(v: number, opts?: ClampOpts): void;
+    /** Apply the deferred layout clamp explicitly. */
+    flushClamp(): void;
+}
+
+function makeScrollable({ clientHeight, scrollHeight, clientWidth = 300 }: {
+    clientHeight: number; scrollHeight: number; clientWidth?: number;
+}): ScrollableEl {
+    const el = document.createElement('div') as ScrollableEl;
+    let ch = clientHeight, cw = clientWidth, sh = scrollHeight, st = 0;
+    // Re-clamp the stored offset into the current range (layout clamp).
+    const clampScroll = () => {
+        const max = Math.max(0, sh - ch);
+        const clamped = Math.max(0, Math.min(st, max));
+        if (clamped !== st) {
+            st = clamped;
+            el.dispatchEvent(new Event('scroll'));
+        }
+    };
+    Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => ch });
+    Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => cw });
+    Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => sh });
+    Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: () => st,
+        set: (v: number) => {
+            const max = Math.max(0, sh - ch);
+            const clamped = Math.max(0, Math.min(v, max));
+            if (clamped !== st) {
+                st = clamped;
+                el.dispatchEvent(new Event('scroll'));
+            }
+        },
+    });
+    el.setClientHeight = (v, opts) => { ch = v; if (!opts?.deferClamp) clampScroll(); };
+    el.setClientWidth = (v) => { cw = v; };
+    el.setScrollHeight = (v, opts) => { sh = v; if (!opts?.deferClamp) clampScroll(); };
+    el.flushClamp = clampScroll;
+    document.body.appendChild(el);
+    return el;
+}
+
+// ---- window / document scroll fake --------------------------------------
+
+interface WindowHarness {
+    setClientHeight(v: number): void;
+    setScrollHeight(v: number): void;
+    /**
+     * Grow scrollHeight with NO scroll/resize dispatch — a post body that
+     * loads after mount. Growth upward never clamps scrollY, so a real engine
+     * fires nothing here either; the module's stored gap goes stale.
+     */
+    setScrollHeightSilent(v: number): void;
+    setInnerWidth(v: number): void;
+    setScrollY(v: number): void;
+    /** Simulate a user scroll: clamp into range and dispatch 'scroll'. */
+    userScroll(v: number): void;
+    readonly scrollY: number;
+    resize(): void;
+}
+
+function makeWindowHarness({ clientHeight = 800, scrollHeight = 2000, scrollY = 0, innerWidth = 390 }: {
+    clientHeight?: number; scrollHeight?: number; scrollY?: number; innerWidth?: number;
+} = {}): WindowHarness {
+    const doc = document.documentElement;
+    let ch = clientHeight, sh = scrollHeight, sy = scrollY, iw = innerWidth;
+    // Layout clamp: a height change re-pins scrollY into the new range before
+    // any resize callback runs.
+    const clampScroll = () => {
+        const max = Math.max(0, sh - ch);
+        const clamped = Math.max(0, Math.min(sy, max));
+        if (clamped !== sy) {
+            sy = clamped;
+            window.dispatchEvent(new Event('scroll'));
+        }
+    };
+    Object.defineProperty(doc, 'clientHeight', { configurable: true, get: () => ch });
+    Object.defineProperty(doc, 'scrollHeight', { configurable: true, get: () => sh });
+    Object.defineProperty(window, 'scrollY', { configurable: true, get: () => sy });
+    Object.defineProperty(window, 'scrollX', { configurable: true, get: () => 0 });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, get: () => iw });
+    window.scrollTo = ((x?: number, y?: number) => {
+        const max = Math.max(0, sh - ch);
+        const clamped = Math.max(0, Math.min(y ?? 0, max));
+        if (clamped !== sy) {
+            sy = clamped;
+            window.dispatchEvent(new Event('scroll'));
+        }
+    }) as unknown as typeof window.scrollTo;
+    return {
+        setClientHeight: (v) => { ch = v; clampScroll(); },
+        setScrollHeight: (v) => { sh = v; clampScroll(); },
+        setScrollHeightSilent: (v) => { sh = v; },
+        setInnerWidth: (v) => { iw = v; },
+        setScrollY: (v) => { sy = v; },
+        userScroll: (v) => {
+            const max = Math.max(0, sh - ch);
+            const clamped = Math.max(0, Math.min(v, max));
+            if (clamped !== sy) {
+                sy = clamped;
+                window.dispatchEvent(new Event('scroll'));
+            }
+        },
+        get scrollY() { return sy; },
+        resize: () => { window.dispatchEvent(new Event('resize')); },
+    };
+}
+
+// ---- injectable keyboard tracker ----------------------------------------
+
+interface FakeTracker {
+    tracker: KeyboardTracker;
+    state: { insetPx: number; visible: boolean };
+    fire(): void;
+}
+
+function makeFakeTracker(init: { insetPx?: number; visible?: boolean } = {}): FakeTracker {
+    const state: KeyboardState = {
+        ...INITIAL_KEYBOARD_STATE,
+        insetPx: init.insetPx ?? 0,
+        visible: init.visible ?? false,
+    };
+    const cbs: Array<(s: KeyboardState) => void> = [];
+    const tracker: KeyboardTracker = {
+        getState: () => state,
+        subscribe: (cb) => {
+            cbs.push(cb);
+            return () => {
+                const i = cbs.indexOf(cb);
+                if (i >= 0) cbs.splice(i, 1);
+            };
+        },
+        setOverride: () => {},
+        destroy: () => {},
+    };
+    const mutable = state as unknown as { insetPx: number; visible: boolean };
+    return {
+        tracker,
+        state: mutable,
+        fire: () => { for (const cb of cbs.slice()) cb(state); },
+    };
+}
+
+function focusEditable(): HTMLTextAreaElement {
+    const ta = document.createElement('textarea');
+    document.body.appendChild(ta);
+    ta.focus();
+    return ta;
+}
+
+// jsdom shares one `window` across a file, so window anchors must all be
+// detached between tests or their stale resize listeners keep firing.
+let detachers: Array<() => void>;
+
+function mount(target: HTMLElement | Window, opts: Parameters<typeof createBottomAnchor>[1]): () => void {
+    const detach = createBottomAnchor(target, opts);
+    detachers.push(detach);
+    return detach;
+}
+
+beforeEach(() => {
+    roInstances = [];
+    detachers = [];
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+});
+
+afterEach(() => {
+    for (const d of detachers) d();
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+});
+
+// =========================================================================
+// element target
+// =========================================================================
+
+describe('element / at-bottom', () => {
+    it('scrolls to the bottom on the first ResizeObserver tick (startAtBottom default)', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'at-bottom' });
+        lastRO().fire();
+        expect(el.scrollTop).toBe(500); // scrollHeight - clientHeight
+    });
+
+    it('does not move on attach when startAtBottom is false', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'at-bottom', startAtBottom: false });
+        lastRO().fire();
+        expect(el.scrollTop).toBe(0);
+    });
+
+    it('re-glues an at-bottom user across a shrink', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'at-bottom' });
+        lastRO().fire(); // -> scrollTop 500, at bottom
+        el.setClientHeight(300); // keyboard steals 200
+        lastRO().fire();
+        expect(el.scrollTop).toBe(700); // 1000 - 300, still glued to bottom
+    });
+
+    it('keeps a scrolled-up user in place across a shrink', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'at-bottom' });
+        lastRO().fire();
+        el.scrollTop = 100; // user scrolls up (>40 slack from bottom)
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(100); // untouched
+    });
+
+    it('re-glues a glued user to the bottom across a width change (reflow / rotation)', () => {
+        // New semantics: on a width-change RO tick the old gap is incomparable,
+        // but a user who WAS glued stays glued (re-anchored to the new bottom),
+        // and nothing is delta-compensated.
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000, clientWidth: 300 });
+        mount(el, { pin: 'at-bottom' });
+        lastRO().fire(); // -> scrollTop 500 (glued)
+        el.setClientWidth(250);
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(700); // re-glued to the new bottom (1000 - 300)
+    });
+
+    it('leaves a scrolled-up user in place across a width change', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000, clientWidth: 300 });
+        mount(el, { pin: 'at-bottom' });
+        lastRO().fire();
+        el.scrollTop = 100; // scrolled up, not glued
+        el.setClientWidth(250);
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(100); // width change never delta-compensates a non-glued user
+    });
+
+    // --- regression: geometry-seeded at-bottom state -------------------------
+    it('does NOT yank a top reader to the bottom on the first shrink (startAtBottom:false)', () => {
+        // The at-bottom state must be seeded from real geometry, not assumed
+        // true: a reader mounted at scrollTop 0 with startAtBottom:false is far
+        // from the bottom, so a keyboard shrink must leave them where they are.
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'at-bottom', startAtBottom: false });
+        lastRO().fire(); // seeds gap from geometry (gap 500 > slack), no move
+        el.setClientHeight(300); // keyboard opens
+        lastRO().fire();
+        expect(el.scrollTop).toBe(0); // NOT yanked to 700
+    });
+
+    // --- regression: first RO tick reports width 0, real width arrives later --
+    it('lands a default-mount user at the bottom when the real width arrives on a later tick', () => {
+        // Container reports 0×0 on the first RO tick (not laid out yet), then a
+        // later tick delivers the real box. The width-change re-glue must land
+        // the glued user at the settled bottom.
+        const el = makeScrollable({ clientHeight: 0, scrollHeight: 0, clientWidth: 0 });
+        mount(el, { pin: 'at-bottom' }); // startAtBottom default true
+        lastRO().fire(); // first tick: 0×0, glued (gap 0)
+        el.setScrollHeight(1000);
+        el.setClientHeight(500);
+        el.setClientWidth(300); // real layout
+        lastRO().fire();
+        expect(el.scrollTop).toBe(500); // settled at the bottom (1000 - 500)
+    });
+});
+
+describe('element / always', () => {
+    it('preserves the bottom edge for a mid-history user (absolute gap-preserving write)', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'always', startAtBottom: false });
+        lastRO().fire(); // establishes lastHeight = 500
+        el.scrollTop = 200; // mid history
+        el.setClientHeight(300); // shrink by 200
+        lastRO().fire();
+        expect(el.scrollTop).toBe(400); // 200 content px above the bottom preserved
+    });
+
+    it('restores symmetrically on the following grow', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'always', startAtBottom: false });
+        lastRO().fire();
+        el.scrollTop = 200;
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(400);
+        el.setClientHeight(500); // grow back
+        lastRO().fire();
+        expect(el.scrollTop).toBe(200); // fold-out restores the original edge
+    });
+
+    it('keeps an at-bottom user glued through shrink then grow via clamping', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'always' });
+        lastRO().fire(); // -> scrollTop 500 (bottom)
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(700); // still bottom (1000 - 300)
+        el.setClientHeight(500); // grow back; layout clamps 700 -> 500 first
+        lastRO().fire();
+        expect(el.scrollTop).toBe(500); // absolute write is a no-op against the clamp
+    });
+
+    // --- regression (defect 4): width change re-glues a glued 'always' user --
+    // Being at the bottom is reflow-invariant, so a glued user must re-anchor
+    // to the new bottom in 'always' too (rotation). The old gap is still not
+    // delta-compensated — only the glued case moves.
+    it('re-glues a glued user to the new bottom on a width change', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000, clientWidth: 300 });
+        mount(el, { pin: 'always' });
+        lastRO().fire(); // -> scrollTop 500 (glued)
+        el.setClientWidth(250);
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(700); // re-glued to the new bottom (1000 - 300)
+    });
+
+    it('leaves a scrolled-up user in place across a width change', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000, clientWidth: 300 });
+        mount(el, { pin: 'always' });
+        lastRO().fire(); // -> scrollTop 500 (glued)
+        el.scrollTop = 100; // scroll up, gap 400 > slack
+        el.setClientWidth(250);
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(100); // reflow never delta-compensates a non-glued user
+    });
+
+    // --- regression (defect 1): grow double-compensation at the bottom -------
+    // On a keyboard-dismiss grow while glued to the bottom, the engine clamps
+    // scrollTop down during layout BEFORE the RO tick. The old relative write
+    // ("scrollTop += dismiss delta") then moved a SECOND time, stranding the
+    // list ~keyboard-height above the bottom. The absolute write must land the
+    // user exactly at the new max regardless of clamp/RO event order.
+    it('does not double-compensate on grow at the bottom — clamp fires before the RO tick', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'always' });
+        lastRO().fire(); // scrollTop 500 (bottom)
+        el.setClientHeight(300); // keyboard opens (steals 200)
+        lastRO().fire();
+        expect(el.scrollTop).toBe(700); // bottom while open
+        el.setClientHeight(500); // keyboard dismisses (grows 200); clamp 700 -> 500 now
+        lastRO().fire();
+        expect(el.scrollTop).toBe(500); // new max, NOT max - 200 (== 300)
+    });
+
+    it('does not double-compensate on grow at the bottom — RO tick before the clamp scroll', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        mount(el, { pin: 'always' });
+        lastRO().fire();
+        el.setClientHeight(300);
+        lastRO().fire();
+        expect(el.scrollTop).toBe(700);
+        el.setClientHeight(500, { deferClamp: true }); // grow, but hold the clamp
+        lastRO().fire(); // RO runs while scrollTop is still the stale 700
+        el.flushClamp(); // engine clamp lands afterwards
+        expect(el.scrollTop).toBe(500); // still the new max, no second move
+    });
+
+    // --- regression (defect 1): near-bottom fold preserved across the clamp ---
+    // A user 60px above the bottom with the keyboard up. On dismiss the grow
+    // over-runs the new max, so the engine clamp scroll fires FIRST (while
+    // clientHeight already reports the new height). onScroll must ignore that
+    // in-flight clamp, or it re-baselines the stored gap to 0 and the RO tick
+    // snaps the user to the exact bottom instead of preserving the 60px fold.
+    it('preserves a 60px fold on grow when the clamp scroll fires before the RO tick', () => {
+        const el = makeScrollable({ clientHeight: 800, scrollHeight: 2000 });
+        mount(el, { pin: 'always' });
+        lastRO().fire(); // -> scrollTop 1200 (bottom)
+        el.setClientHeight(500); // keyboard opens (steals 300)
+        lastRO().fire();
+        expect(el.scrollTop).toBe(1500); // bottom while open (2000 - 500)
+        el.scrollTop = 1440; // user scrolls up 60px from the bottom -> gap 60
+        el.setClientHeight(800); // dismiss grows; clamp 1440 -> new max 1200 fires first
+        lastRO().fire();
+        expect(el.scrollTop).toBe(1140); // max - 60, fold preserved (NOT 1200)
+    });
+});
+
+// =========================================================================
+// window target
+// =========================================================================
+
+describe('window / always', () => {
+    it('compensates a shrink while an editable is focused and undoes it on grow', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // keyboard 300
+        h.resize();
+        expect(h.scrollY).toBe(800); // 500 + 300
+
+        h.setClientHeight(800); // keyboard closes
+        h.resize();
+        expect(h.scrollY).toBe(500); // undone
+    });
+
+    it('ignores an unfocused chrome shrink and its matching grow (no drift)', () => {
+        const kb = makeFakeTracker({ insetPx: 0, visible: false });
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(740); // URL bar reveals, 60px, no focus/keyboard
+        h.resize();
+        expect(h.scrollY).toBe(500); // gate closed
+
+        h.setClientHeight(800); // URL bar hides again
+        h.resize();
+        expect(h.scrollY).toBe(500); // no phantom debt to give back
+    });
+
+    it('caps the grow undo at the shrink actually applied', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 0 });
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // shrink 300 from the top
+        h.resize();
+        expect(h.scrollY).toBe(300); // outstanding debt = 300
+
+        h.setClientHeight(900); // grows 400 (> keyboard: URL bar hid too)
+        h.resize();
+        expect(h.scrollY).toBe(0); // undo capped at 300, clamps to top, no over-scroll
+    });
+
+    it('drops the debt on an orientation (width) change', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 0, innerWidth: 390 });
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500);
+        h.resize();
+        expect(h.scrollY).toBe(300); // debt built
+
+        h.setInnerWidth(800); // rotate
+        h.resize();
+        expect(h.scrollY).toBe(300); // orientation evaluate moves nothing
+
+        h.setClientHeight(800); // a grow that WOULD undo if debt survived
+        h.resize();
+        expect(h.scrollY).toBe(300); // debt was reset -> no undo
+    });
+
+    it('compensates an overlay-mode inset change (clientHeight fixed) the same way', () => {
+        const kb = makeFakeTracker({ insetPx: 0, visible: true });
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        kb.state.insetPx = 300; // overlay keyboard occludes 300, layout unchanged
+        kb.fire(); // tracker subscriber drives evaluate
+        expect(h.scrollY).toBe(800); // effectiveHeight fell 300 -> same compensation
+    });
+
+    // --- regression (defect 2): grow double-compensation at document bottom ---
+    // Same shape as defect 1 but for the window anchor: at the document bottom
+    // the layout clamp restores the glued user on grow BEFORE the resize
+    // callback, so the absolute write must be a no-op, not a second delta.
+    //
+    // This also pins the round-5 clamp-signature fallback: the grow branch
+    // normally prefers a FRESH baseline, but here the geometry bears the engine
+    // clamp's signature (scrollY pinned at the document bottom, scrollY >=
+    // maxScroll - 1), so it must fall back to the STORED gap. The fresh read
+    // would be post-clamp (2000 - 1200 - 500 = 300) and land the page at 900 —
+    // a second move; the stored gap (0) is the only pre-event truth and lands
+    // it back at the true bottom.
+    it('does not double-compensate a focused shrink/grow at the document bottom (clamp-signature stored-gap path)', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 1200 }); // bottom
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // keyboard 300
+        h.resize();
+        expect(h.scrollY).toBe(1500); // bottom while open (max 1500)
+
+        h.setClientHeight(800); // keyboard dismisses; clamp 1500 -> 1200 fires first (the signature)
+        h.resize();
+        expect(h.scrollY).toBe(1200); // stored-gap fallback, NOT 900 (fresh-baseline double move)
+    });
+
+    // --- regression (defect 3): clamped fold-out must not strand debt ---------
+    // A fold-out that clamps at scrollY 0 achieves less movement than the debt.
+    // Draining debt by ACHIEVED movement leaves debt > 0 forever, holding the
+    // keyboardish gate open so later URL-bar chrome noise drifts the page.
+    // Nominal draining (debt -= min(growth, debt)) fully clears it.
+    it('drains debt nominally when the fold-out clamps at the top (no later chrome drift)', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 0 });
+        const ta = focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // keyboard opens, shrink 300 (focused)
+        h.resize();
+        expect(h.scrollY).toBe(300); // compensated, debt = 300
+
+        h.userScroll(20); // user scrolls back up near the top
+        expect(h.scrollY).toBe(20);
+
+        ta.remove(); // blur (focus element unmounts)
+        h.setClientHeight(800); // keyboard dismisses, grow 300; fold-out clamps at 0
+        h.resize();
+        expect(h.scrollY).toBe(0); // clamped at the top; debt drained nominally to 0
+
+        h.setClientHeight(740); // later unfocused URL-bar chrome shrink (60)
+        h.resize();
+        expect(h.scrollY).toBe(0); // gate closed (debt == 0) -> NOT dragged down
+    });
+
+    // --- regression (defect 2): overlay carry ledger repays the un-foldable px --
+    // An overlay host at the document bottom cannot scroll past the physical
+    // edge, so the fold-in clamps and the stored gap absorbs the un-foldable
+    // px. Without the carry ledger, fold-out replays that gap and drifts the
+    // page up by ~keyboard-height. The carry records the clamped shortfall and
+    // fold-out subtracts it, returning the page to its true edge.
+    it('repays the clamped fold on fold-out at the document bottom (overlay host)', () => {
+        const kb = makeFakeTracker({ insetPx: 0, visible: true });
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 1200 }); // bottom, max 1200
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        kb.state.insetPx = 300; // fold-in: effectiveHeight 800 -> 500, clamps at max 1200
+        kb.fire();
+        expect(h.scrollY).toBe(1200); // could not scroll past the edge (carry = 300)
+
+        kb.state.insetPx = 0; // fold-out
+        kb.fire();
+        expect(h.scrollY).toBe(1200); // back at the true bottom (carry repaid), NOT 900
+    });
+
+    it('repays the clamped fold for a near-bottom overlay user (gap 60)', () => {
+        const kb = makeFakeTracker({ insetPx: 0, visible: true });
+        // scrollY 1140 = 60px above the bottom (max 1200).
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 1140 });
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        kb.state.insetPx = 300; // fold-in clamps at the edge, part of the fold un-foldable
+        kb.fire();
+        expect(h.scrollY).toBe(1200);
+
+        kb.state.insetPx = 0; // fold-out
+        kb.fire();
+        expect(h.scrollY).toBe(1140); // returns to the true gap (max - 60), NOT 900
+    });
+
+    // --- regression (defect 3): SHRINK baseline read fresh, survives silent grow --
+    // Content loads after mount and grows scrollHeight with no scroll/resize
+    // event, so the stored gap is stale (still ~0). The first keyboard shrink
+    // must read the gap FRESH against the pre-event height (a shrink is never
+    // engine-clamped) and fold by the keyboard height, not jump to the new
+    // document bottom off the stale stored gap.
+    it('folds by the keyboard height after a silent content grow (fresh shrink baseline)', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 800, scrollY: 0 }); // short doc, gap ~0
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setScrollHeightSilent(2800); // post body loads: +2000, no event -> stored gap stale
+        focusEditable();
+
+        h.setClientHeight(500); // keyboard opens, shrink 300 (focused)
+        h.resize();
+        expect(h.scrollY).toBe(300); // folded by 300 off the FRESH gap, NOT jumped to 2300
+    });
+});
+
+describe('window / at-bottom', () => {
+    it('compensates a shrink only when the user is at the bottom', () => {
+        // At bottom: compensated.
+        const kb1 = makeFakeTracker();
+        const bottom = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 1200 });
+        focusEditable();
+        const detach1 = mount(window, { pin: 'at-bottom', tracker: kb1.tracker });
+        bottom.setClientHeight(500);
+        bottom.resize();
+        expect(bottom.scrollY).toBe(1500); // 1200 + 300, glued to bottom
+        detach1();
+    });
+
+    it('does not compensate a shrink when the user is mid-page', () => {
+        const kb = makeFakeTracker();
+        const mid = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        focusEditable();
+        mount(window, { pin: 'at-bottom', tracker: kb.tracker });
+        mid.setClientHeight(500);
+        mid.resize();
+        expect(mid.scrollY).toBe(500); // not at bottom -> untouched
+    });
+
+    it('drains the debt on keyboard close so a later unfocused shrink does not drift', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 1200 });
+        const ta = focusEditable();
+        mount(window, { pin: 'at-bottom', tracker: kb.tracker });
+
+        h.setClientHeight(500); // keyboard opens at bottom
+        h.resize();
+        expect(h.scrollY).toBe(1500); // debt = 300
+
+        ta.remove(); // keyboard closes, focus gone
+        h.setClientHeight(800); // layout grows back; clamp restores the glued user to 1200
+        h.resize();
+        // 'at-bottom' grow drains the debt nominally without its own scroll write.
+        expect(h.scrollY).toBe(1200); // engine clamp re-anchored to the new bottom
+
+        h.setClientHeight(740); // later URL-bar chrome shrink, still unfocused
+        h.resize();
+        expect(h.scrollY).toBe(1200); // gate closed (debt drained) -> no drift
+    });
+});
+
+// =========================================================================
+// round-4 regressions
+// =========================================================================
+
+describe('round-4 regressions', () => {
+    // --- fix 1: a live user drag during a multi-frame grow is respected ------
+    // Keyboard dismissal grows the box over several frames. Each grow tick runs
+    // AFTER the frame's scroll steps, so if the onScroll guard swallowed every
+    // scroll while a grow was in flight, the stored gap would be frozen and each
+    // tick would yank the user back to their pre-dismiss position, fighting the
+    // drag. The guard must swallow ONLY the engine clamp (grow in flight AND
+    // landing exactly at the new bottom); a mid-range user drag re-baselines the
+    // stored gap live, so the tick preserves where the user actually is.
+    it('preserves a live user drag through a multi-frame grow (always)', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 2000 });
+        mount(el, { pin: 'always', startAtBottom: false });
+        lastRO().fire(); // lastHeight = 500
+        el.scrollTop = 1200; // mid-history, keyboard up -> gap 300
+        // Frame 1: box grows 500 -> 600 (clamp leaves a mid-range scrollTop put),
+        // then the user drags to a new mid-range spot BEFORE the RO delivers.
+        el.setClientHeight(600);
+        el.scrollTop = 1000; // user drag -> gap 400, readGap far from 0 -> not swallowed
+        lastRO().fire();
+        expect(el.scrollTop).toBe(1000); // the user's gap 400, NOT reverted to 300 (->1100)
+        // Frame 2: same again, proving no fight across successive grow ticks.
+        el.setClientHeight(700);
+        el.scrollTop = 900; // user drag -> gap 400
+        lastRO().fire();
+        expect(el.scrollTop).toBe(900); // still the user's position, NOT 300 (->1000)
+    });
+
+    // --- fix 1 (negative): the guard is grow-only; shrinks re-baseline --------
+    // The 60px-fold test above proves a clamp landing at the bottom is swallowed
+    // during a GROW. The mirror: during a SHRINK in flight (clientHeight already
+    // below lastHeight, RO not yet delivered) a user scroll — even one landing
+    // exactly at the new bottom, which the grow guard WOULD swallow — must
+    // re-baseline the stored gap, because a shrink is never engine-clamped so
+    // any scroll is genuinely the user.
+    it('re-baselines a shrink-in-flight scroll that lands at the bottom (guard is grow-only)', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 2000 });
+        mount(el, { pin: 'always', startAtBottom: false });
+        lastRO().fire(); // lastHeight = 500
+        el.scrollTop = 1200; // keyboard-up mid-history -> gap 300
+        // Shrink in flight: box drops 500 -> 300, RO not delivered (lastHeight
+        // still 500). User drags to the NEW bottom during that window.
+        el.setClientHeight(300);
+        el.scrollTop = 1700; // new bottom, readGap 0 -> a GROW would swallow this
+        // clientHeight(300) < lastHeight(500), so the guard lets it through and
+        // gap re-baselines to 0. Observe via the following dismiss grow, which
+        // reads the stored gap.
+        el.setClientHeight(800); // grow; clamp 1700 -> new max 1200 fires (swallowed)
+        lastRO().fire();
+        expect(el.scrollTop).toBe(1200); // folded out off gap 0, NOT 900 (stale gap 300)
+    });
+
+    // --- fix 2: writeGap forces an instant scroll and restores the prior value -
+    // Under a consumer's `scroll-behavior: smooth` the window write would animate
+    // asynchronously, so the carry readback right after it would measure a
+    // phantom shortfall and drift the page. writeGap must set the scroller's
+    // inline scrollBehavior to 'auto' for the duration of the scrollTo, then
+    // restore whatever inline value was there before. (scrollingElement is
+    // undefined under jsdom, so the scroller is documentElement — matching the
+    // source's `document.scrollingElement ?? doc`.)
+    it('forces scrollBehavior:auto during the write and restores the default afterwards', () => {
+        const de = document.documentElement;
+        de.style.scrollBehavior = ''; // no consumer preset
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        const orig = window.scrollTo;
+        let seen: string | undefined;
+        window.scrollTo = ((x?: number, y?: number) => {
+            seen = de.style.scrollBehavior; // sampled synchronously inside the write
+            return (orig as (x?: number, y?: number) => void)(x, y);
+        }) as typeof window.scrollTo;
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // focused shrink drives writeGap
+        h.resize();
+        expect(h.scrollY).toBe(800); // compensation happened (write ran)
+        expect(seen).toBe('auto'); // instant, not the consumer's behavior
+        expect(de.style.scrollBehavior).toBe(''); // restored to the prior inline value
+        window.scrollTo = orig;
+    });
+
+    it('restores a consumer preset scrollBehavior:smooth after the forced write', () => {
+        const de = document.documentElement;
+        de.style.scrollBehavior = 'smooth'; // consumer preset
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        const orig = window.scrollTo;
+        let seen: string | undefined;
+        window.scrollTo = ((x?: number, y?: number) => {
+            seen = de.style.scrollBehavior;
+            return (orig as (x?: number, y?: number) => void)(x, y);
+        }) as typeof window.scrollTo;
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500);
+        h.resize();
+        expect(h.scrollY).toBe(800);
+        expect(seen).toBe('auto'); // forced instant even under smooth
+        expect(de.style.scrollBehavior).toBe('smooth'); // preset restored, not clobbered
+        window.scrollTo = orig;
+        de.style.scrollBehavior = ''; // avoid leaking into other tests
+    });
+});
+
+// =========================================================================
+// round-5 regressions
+// =========================================================================
+
+describe('round-5 regressions', () => {
+    // --- the round-4 confirmed defect: a silent document grow under an open
+    // keyboard must not hijack the fold-out. The window GROW branch used to
+    // trust the STORED gap unconditionally; if the document grew with no event
+    // while the keyboard was up (a placeholder->data swap, a post body
+    // resolving), that gap was stale and dismissal jumped the page toward the
+    // new document bottom. Round 5 prefers a FRESH baseline
+    // (scrollHeight - scrollY - prevHeight) unless the geometry bears the engine
+    // clamp's signature (scrollY pinned at the document bottom). A silent grow
+    // moves the bottom away from the user, so it can never fake the signature.
+    it('folds out from the current position after a silent grow, not toward the new bottom (always)', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 850, scrollY: 0 }); // short doc, gap ~50
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // keyboard opens, focused shrink 300
+        h.resize();
+        expect(h.scrollY).toBe(300); // folded to the bottom edge, debt = 300
+
+        h.setScrollHeightSilent(3000); // content resolves under the open keyboard, no event -> stored gap (50) stale
+
+        h.setClientHeight(800); // keyboard dismisses, grow 300; scrollY 300 is far from the new bottom (max 2200)
+        h.resize();
+        // Fresh baseline 3000 - 300 - 500 = 2200 folds back out by 300 to
+        // scrollY 0. The stale stored gap (50) would have written toward the
+        // new document bottom (y = 3000 - 800 - 50 = 2150).
+        expect(h.scrollY).toBe(0);
+    });
+
+    // --- composer auto-grow variant: a textarea growing a few px under the open
+    // keyboard is the same stale-stored-gap mechanism at small scale. A 66px
+    // growth would leak into the restored position off the stored gap; the fresh
+    // baseline restores the exact pre-open scroll position with no drift.
+    it('restores the exact pre-open position after a 66px composer auto-grow (no drift, always)', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 }); // mid-page
+        focusEditable();
+        mount(window, { pin: 'always', tracker: kb.tracker });
+
+        h.setClientHeight(500); // keyboard opens, focused shrink 300
+        h.resize();
+        expect(h.scrollY).toBe(800); // folded up (500 + 300), gap 700 preserved
+
+        h.setScrollHeightSilent(2066); // composer auto-grows 66px, no event
+
+        h.setClientHeight(800); // keyboard dismisses, grow 300
+        h.resize();
+        // Fresh baseline 2066 - 800 - 500 = 766 restores scrollY 500 exactly;
+        // the stale stored gap (700) would land at 566, drifted up by the 66px.
+        expect(Math.abs(h.scrollY - 500)).toBeLessThanOrEqual(1);
+    });
+});
+
+// =========================================================================
+// cleanup
+// =========================================================================
+
+describe('cleanup', () => {
+    it('detaches the window anchor: later events move nothing', () => {
+        const kb = makeFakeTracker();
+        const h = makeWindowHarness({ clientHeight: 800, scrollHeight: 2000, scrollY: 500 });
+        focusEditable();
+        const detach = mount(window, { pin: 'always', tracker: kb.tracker });
+        detach();
+
+        h.setClientHeight(500);
+        h.resize(); // resize listener removed
+        kb.state.insetPx = 300;
+        kb.fire(); // subscriber removed
+        expect(h.scrollY).toBe(500); // untouched
+    });
+
+    it('detaches the element anchor: the ResizeObserver is disconnected', () => {
+        const el = makeScrollable({ clientHeight: 500, scrollHeight: 1000 });
+        const detach = mount(el, { pin: 'always' });
+        const ro = lastRO();
+        ro.fire();
+        detach();
+        expect(ro.disconnected).toBe(true);
+    });
+});

--- a/src/app/chat/components/ChatRoomDetail.tsx
+++ b/src/app/chat/components/ChatRoomDetail.tsx
@@ -464,7 +464,7 @@ export default function ChatRoomDetail({ roomId, room, onMenuClick, exitTo = '/c
     // 컨테이너가 리사이즈될 때(키보드로 채팅 컬럼이 줄어들 때) 바닥 앵커 유지.
     // 사용자가 위로 스크롤해 둔 경우에는 읽던 위치를 그대로 보존한다.
     // 새 메시지 스크롤은 위의 [messages] 이펙트가 담당(컨텐츠 성장은 RO에 안 잡힘).
-    useBottomAnchoredScroll(messageContainerRef);
+    useBottomAnchoredScroll(messageContainerRef, { pin: 'always' });
 
     // 메시지 삭제 핸들러
     const handleDeleteMessage = async () => {

--- a/src/app/web_view/Post/[id]/page.tsx
+++ b/src/app/web_view/Post/[id]/page.tsx
@@ -16,6 +16,7 @@ import { AppHeader, CenteredSpinner, ComposerSpacer, ContentArea, LeftChevronIco
 import { useSafeBack } from '@/app/web_view/hooks/useSafeBack';
 import { usePullToRefresh } from '@/app/web_view/hooks/usePullToRefresh';
 import { usePost } from '@/app/web_view/_query';
+import { useWindowBottomAnchoredScroll } from '@sparcs-kaist/keyboard-inset/react';
 import { ArticleHeader } from './_components/ArticleHeader';
 import { Attachments } from './_components/Attachments';
 import { CommentComposer } from './_components/CommentComposer';
@@ -60,6 +61,10 @@ export default function WebViewPostDetailPage() {
     const reload = useCallback(() => postQuery.refetch(), [postQuery]);
 
     usePullToRefresh(reload);
+
+    // Messenger-style fold: preserve the bottom-edge content (comments above the
+    // fixed composer) when the keyboard resizes the document, wherever the user is.
+    useWindowBottomAnchoredScroll();
 
     /** Optimistic mutate of the cached post so VoteRow / scrap buttons stay snappy. */
     const patchPost = useCallback(


### PR DESCRIPTION
…pin mode

Add createBottomAnchor to @sparcs-kaist/keyboard-inset (0.2.0): keep a scroller's bottom edge anchored across keyboard-driven height changes, parameterized per surface — pin: 'at-bottom' re-glues only users already at the bottom (feed style), pin: 'always' folds the view against the keyboard the way messenger apps do (KakaoTalk / Instagram DM / Slack). React bindings: a pin option on useBottomAnchoredScroll and a new useWindowBottomAnchoredScroll for document-scrolling pages.

Mechanics the API guarantees:
- absolute gap-preserving writes: engines clamp scroll offsets at layout before callbacks run, so relative deltas would double-compensate
- direction-dependent baselines: a shrink reads fresh against the pre-event height (survives content that grew without scroll events); a grow trusts the stored gap only under the engine clamp signature
- nominal debt gate so URL-bar chrome noise can never drift the page
- carry ledger repaying folds clamped at the document edge on overlay hosts, and instant-scroll force under consumer scroll-behavior:smooth
- element scroll guard that swallows the clamp's own scroll event but honors live user drags during multi-frame keyboard animations

Wire the chat column and the post view (document scroller) to the messenger fold. 37 scroll-anchor tests on a layout-clamp-accurate jsdom harness.