### PR TITLE
fix(webview): hand the composer's resting offset to the keyboard cont…

### DIFF
--- a/src/app/web_view/Chat/[id]/page.tsx
+++ b/src/app/web_view/Chat/[id]/page.tsx
@@ -131,9 +131,15 @@ export default function WebViewChatRoomPage() {
                 height: 'var(--kb-visual-height, 100dvh)',
                 // Keep the room header out from under the fixed safe-top cap.
                 paddingTop: 'var(--ara-safe-top, env(safe-area-inset-top, 0px))',
-                // Home-indicator clearance, zeroed while the keyboard covers it.
+                // Home-indicator clearance, handed off continuously to the
+                // keyboard (see StickyComposer's resting-offset rationale).
+                // Both shrink terms: resize hosts move --ara-kb-shrink
+                // (synchronous), overlay hosts move --kb-inset (same tracker
+                // timing as the --kb-visual-height column height above) —
+                // without the inset term the clearance never collapses under
+                // an overlay keyboard and the input floats above it.
                 paddingBottom:
-                    'calc(var(--ara-safe-bottom, env(safe-area-inset-bottom, 0px)) * (1 - var(--kb-visible, 0)))',
+                    'max(0px, calc(var(--ara-safe-bottom, env(safe-area-inset-bottom, 0px)) - var(--ara-kb-shrink, 0px) - var(--kb-inset, 0px)))',
             }}
         >
             <ChatRoomDetail

--- a/src/app/web_view/Post/[id]/_components/CommentComposer.tsx
+++ b/src/app/web_view/Post/[id]/_components/CommentComposer.tsx
@@ -32,7 +32,7 @@ const MAX_LINES = 5;
  *   │      │ #f8f8f8 rounded-10 input   │ send 30  │
  *   └──────────────────────────────────────────────┘
  *
- * Lifts above the keyboard via `StickyComposer` (--kb-inset / --kb-visible).
+ * Lifts above the keyboard via `StickyComposer` (--kb-inset / --ara-kb-shrink).
  */
 export function CommentComposer({
     postId,

--- a/src/app/web_view/_components/StickyComposer.tsx
+++ b/src/app/web_view/_components/StickyComposer.tsx
@@ -9,10 +9,14 @@ interface StickyComposerProps {
     className?: string;
 }
 
-// Home-indicator clearance, zeroed while the keyboard is up (it covers that
-// zone — the composer should sit flush against the keyboard).
+// Home-indicator clearance, handed off to the keyboard CONTINUOUSLY: the
+// resting offset gives way px-for-px as the layout viewport shrinks, so the
+// bar holds its absolute screen position until the rising keyboard reaches
+// it, then rides flush on top. Gating this on the binary --kb-visible
+// instead made the bar snap by the safe-bottom height mid-animation — that
+// flag lands rAF + stability frames after the geometry moves.
 const CLOSED_RESTING_OFFSET =
-    'calc(var(--ara-safe-bottom, env(safe-area-inset-bottom, 0px)) * (1 - var(--kb-visible, 0)))';
+    'max(0px, calc(var(--ara-safe-bottom, env(safe-area-inset-bottom, 0px)) - var(--ara-kb-shrink, 0px)))';
 
 /**
  * Bottom-anchored bar that auto-lifts above the software keyboard:

--- a/src/app/web_view/_components/WebViewClientLayout.tsx
+++ b/src/app/web_view/_components/WebViewClientLayout.tsx
@@ -4,7 +4,7 @@ import { useEffect, type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { BottomTabBar, isTabRoot } from './BottomTabBar';
 import { getBridge, useBridgeEvent } from '../_bridge';
-import { getSharedKeyboardTracker } from '@sparcs-kaist/keyboard-inset';
+import { getSharedKeyboardTracker, isEditableElement } from '@sparcs-kaist/keyboard-inset';
 import { useKeyboardCssVars } from '@sparcs-kaist/keyboard-inset/react';
 import { WebViewQueryProvider } from '../_query';
 import { PageTransition } from './PageTransition';
@@ -44,6 +44,89 @@ export function WebViewClientLayout({ children }: { children: ReactNode }) {
     // (Android) and decided there — it's the only place where the
     // OnBackInvokedDispatcher fires authoritatively before the system
     // can finish the activity. We don't listen for `back:pressed` here.
+
+    // Publish --ara-kb-shrink (layout-viewport shrink in px) SYNCHRONOUSLY
+    // from the resize event. Fixed bottom bars subtract it from their
+    // resting safe-area offset, so the rising keyboard picks them up
+    // continuously mid-flight; the tracker's binary --kb-visible lands
+    // rAF + stability frames later and stepping on it made the bar snap
+    // by the safe-bottom height mid-animation. Width changes reset the
+    // baseline (rotation must re-measure, not read as a giant shrink).
+    // Also stamps data-ara-kb on <html> while a keyboard is plausibly up
+    // (layout shrink, or tracker-visible on overlay hosts) — tokens.css
+    // keys the scroll-anchoring opt-out on it so native anchoring is
+    // disabled only while our folds own the scroll position.
+    useEffect(() => {
+        const root = document.documentElement;
+        const tracker = getSharedKeyboardTracker();
+        let baseWidth = window.innerWidth;
+        let maxHeight = window.innerHeight;
+        let shrink = 0;
+        // Latched through blur so the close animation stays continuous:
+        // the last resize frames arrive after focus is gone.
+        let engaged = false;
+        let settleTimer: number | undefined;
+        const apply = () => {
+            root.style.setProperty('--ara-kb-shrink', `${shrink}px`);
+            if (shrink > 0 || tracker.getState().visible) {
+                root.setAttribute('data-ara-kb', '');
+            } else {
+                root.removeAttribute('data-ara-kb');
+            }
+        };
+        // Keyboard gone but geometry never returned to the ratcheted max
+        // (browser-chrome shrink latched as a close animation): drop the
+        // phantom instead of pinning the composer low until a rotation.
+        // A real shell close reaches shrink 0 well inside the grace window,
+        // making this a no-op there.
+        const releaseIfStuck = () => {
+            settleTimer = undefined;
+            if (shrink === 0) return;
+            if (isEditableElement(document.activeElement) || tracker.getState().visible) return;
+            maxHeight = window.innerHeight;
+            shrink = 0;
+            engaged = false;
+            apply();
+        };
+        const onTrackerChange = () => {
+            apply();
+            if (shrink > 0 && !tracker.getState().visible && settleTimer === undefined) {
+                settleTimer = window.setTimeout(releaseIfStuck, 600);
+            }
+        };
+        const onResize = () => {
+            if (window.innerWidth !== baseWidth) {
+                baseWidth = window.innerWidth;
+                maxHeight = window.innerHeight;
+                engaged = false;
+            }
+            // Only a keyboard-plausible resize counts: browser-chrome
+            // (URL bar / toolbar) height moves with no editable focused,
+            // and attributing those to the keyboard would collapse the
+            // composer clearance while merely reading. Non-keyboard
+            // resizes re-baseline instead. Focus is read synchronously —
+            // the tracker's own flag is rAF-late by design.
+            if (isEditableElement(document.activeElement) || tracker.getState().visible || engaged) {
+                maxHeight = Math.max(maxHeight, window.innerHeight);
+                shrink = Math.max(0, maxHeight - window.innerHeight);
+                engaged = shrink > 0;
+            } else {
+                maxHeight = window.innerHeight;
+                shrink = 0;
+            }
+            apply();
+        };
+        onResize();
+        window.addEventListener('resize', onResize);
+        const unsubscribe = tracker.subscribe(onTrackerChange);
+        return () => {
+            unsubscribe();
+            window.removeEventListener('resize', onResize);
+            if (settleTimer !== undefined) window.clearTimeout(settleTimer);
+            root.style.removeProperty('--ara-kb-shrink');
+            root.removeAttribute('data-ara-kb');
+        };
+    }, []);
 
     // Publish --kb-inset / --kb-visible / --kb-visual-height on <html>
     // (host-agnostic keyboard geometry, see @sparcs-kaist/keyboard-inset).

--- a/src/app/web_view/_styles/tokens.css
+++ b/src/app/web_view/_styles/tokens.css
@@ -18,6 +18,9 @@
     --kb-inset: 0px;
     --kb-visible: 0;
     --kb-visual-height: 100dvh;
+    /* Layout-viewport shrink in px, published synchronously per resize
+       frame by WebViewClientLayout (resize-mode host hand-off). */
+    --ara-kb-shrink: 0px;
 }
 
 [data-ara-shell] {
@@ -43,6 +46,18 @@
 [data-ara-shell] *::before,
 [data-ara-shell] *::after {
     box-sizing: border-box;
+}
+
+/* While a keyboard is up ([data-ara-kb], stamped by WebViewClientLayout),
+   the shell's own bottom-anchored folds own the scroll position; Chromium's
+   scroll anchoring is a second writer with a different target and the two
+   fight for a frame during the per-frame IME resize. Scoped to the keyboard
+   presentation on purpose: with no keyboard, native anchoring still absorbs
+   content growing above the viewport (post images decoding while the reader
+   is down in the comments). */
+[data-ara-shell][data-ara-kb],
+[data-ara-shell][data-ara-kb] * {
+    overflow-anchor: none;
 }
 
 /* Native-app feel: hide every scrollbar inside the WebView shell. The


### PR DESCRIPTION
…inuously

The fixed composer's home-indicator clearance collapsed on the binary --kb-visible flip, which lands rAF + stability frames after the geometry moves on the resize-mode shell — so the bar snapped by the safe-bottom height mid-animation and visibly arrived late. Replace the binary gate with a continuous hand-off: WebViewClientLayout publishes --ara-kb-shrink (layout-viewport shrink, px) synchronously from the resize event, and the resting offset gives way px-for-px, so the bar holds its screen position until the rising keyboard picks it up flush.

Details that keep the other hosts honest:
- shrink accrual is gated on an editable owning focus / tracker-visible, with an engaged latch carrying the post-blur close animation and a 600ms settle release for browser-chrome phantoms (dev browsers)
- the chat column's paddingBottom also subtracts --kb-inset: on overlay hosts shrink is definitionally 0 and without the inset term the input floated a safe-bottom above the keyboard
- Chromium scroll anchoring is disabled only while a keyboard is up (data-ara-kb) — it fought the bottom-anchored folds during the per-frame IME resize, but must keep absorbing content growth above the viewport (post images decoding) the rest of the time